### PR TITLE
Adds useful violation messages for ordered_elements

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeCore.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeCore.kt
@@ -22,6 +22,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.constraint.ConstraintBase
 import com.amazon.ionschema.internal.util.markReadOnly
+import com.amazon.ionschema.internal.util.schemaTypeName
 
 /**
  * Instantiated to represent individual Core Types as defined by the
@@ -36,9 +37,7 @@ internal class TypeCore(
         else -> IonType.valueOf(nameSymbol.stringValue().toUpperCase())
     }
 
-    private val ionTypeName = ionType.schemaTypeName()
-
-    override val name = ionTypeName
+    override val name = ionType.schemaTypeName()
 
     override val schemaId: String? = null
 
@@ -54,7 +53,7 @@ internal class TypeCore(
                 Violation(
                     ion, "type_mismatch",
                     "expected type %s, found %s".format(
-                        ionTypeName,
+                        name,
                         value.type.schemaTypeName()
                     )
                 )
@@ -63,9 +62,4 @@ internal class TypeCore(
             issues.add(CommonViolations.NULL_VALUE(ion))
         }
     }
-}
-
-internal fun IonType.schemaTypeName() = when (this) {
-    IonType.DATAGRAM -> "document"
-    else -> this.toString().toLowerCase()
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/NFA.kt
@@ -34,110 +34,176 @@ package com.amazon.ionschema.internal.constraint
  *
  * For an example of how to model things using this class, see [OrderedElementsNfaStatesBuilder].
  */
-internal class NFA<Event : Any>(
+internal class NFA<Event : Any, ErrorCause : Any>(
     /**
      * An adjacency list describing the transitions between states in the NFA. The adjacency list is modeled as a map of
      * source to list of destinations. Any intermediate state that appears as a destination must also appear as a key in
      * the map. The map must contain [NFA.State.Initial] as a key. There may be no transitions out of [NFA.State.Final].
      */
-    private val transitions: Map<State<Event>, Set<State<Event>>>,
+    private val transitions: Map<State<Event, ErrorCause>, Set<State<Event, ErrorCause>>>,
 ) {
 
     init {
-        require(!transitions[State.Initial].isNullOrEmpty()) { "Invalid graph: no transition from initial state." }
-        require(transitions[State.Final].isNullOrEmpty()) { "Invalid graph: no transitions allowed from final state." }
+        require(!transitions[State.initial()].isNullOrEmpty()) { "Invalid graph: no transition from initial state." }
+        require(transitions[State.final()].isNullOrEmpty()) { "Invalid graph: no transitions allowed from final state." }
         transitions.values.flatten().let { destinations ->
             val unknownDestinations = destinations.filter { it !in transitions.keys && it != State.Final }.distinct()
             require(unknownDestinations.isEmpty()) { "Invalid graph: transitions to unknown states: $unknownDestinations" }
-            require(State.Final in destinations) { "Invalid graph: no transition to final state." }
+            require(State.final() in destinations) { "Invalid graph: no transition to final state." }
         }
     }
 
     companion object { private val END_OF_STREAM_EVENT: Nothing? = null }
-    private val INITIAL_STATE = setOf(StateVisitCount<Event>(State.Initial, 1))
+    private val INITIAL_STATE: TransitionsResult<in Event> = TransitionsResult.StateSet(setOf(StateVisitCount(State.initial(), 1)))
 
-    sealed class State<in Event : Any>(val debugId: String) {
-        open fun canEnter(event: Event?): Boolean = false
+    sealed class State<Event, out ErrorCause : Any> (val debugId: String) {
+        open fun canEnter(event: Event?): Decision<ErrorCause> = Decision(false)
         open fun canReenter(visits: Int): Boolean = false
         open fun canExit(visits: Int): Boolean = false
         final override fun toString(): String = debugId
+        open val description: String = debugId
 
-        object Initial : State<Any>("I") {
+        data class Decision<out T>(val value: Boolean, val details: T? = null)
+
+        companion object {
+            fun <Event : Any> initial(): State<Event, Nothing> = Initial as State<Event, Nothing>
+            fun <Event : Any> final(): State<Event, Nothing> = Final as State<Event, Nothing>
+        }
+        object Initial : State<Any, Nothing>("I") {
             override fun canExit(visits: Int): Boolean = true
+            override fun canEnter(event: Any?): Decision<Nothing> = Decision(false)
+        }
+        object Final : State<Any, Nothing>("F") {
+            override fun canEnter(event: Any?): Decision<Nothing> = Decision(event == END_OF_STREAM_EVENT)
         }
 
-        object Final : State<Any>("F") {
-            override fun canEnter(event: Any?): Boolean = event == END_OF_STREAM_EVENT
-        }
-
-        class Intermediate<Event : Any>(
+        data class Intermediate<Event : Any, ErrorCause : Any>(
             /** Unique identifier for this state. */
             val id: Int,
             /** Condition on the [Event] value for entering this state. */
-            val entryCondition: (Event) -> Boolean,
-            /** Condition on number of visits for re-entering this state. Only applies on a loop (i.e. not S1->S2->S1). */
-            val reentryCondition: (Int) -> Boolean,
+            private val entryCondition: (Event) -> Decision<ErrorCause>,
+            /** Condition on number of visits for re-entering this state. Only applies on a loop (i.e. S1->S1, but not S1->S2->S1). */
+            private val reentryCondition: (Int) -> Boolean,
             /** Condition on number of visits for leaving this state. Does not apply when following a loop (ie. S1->S1). */
-            val exitCondition: (Int) -> Boolean,
-        ) : State<Event>("S$id") {
+            private val exitCondition: (Int) -> Boolean,
 
-            override fun canEnter(event: Event?): Boolean = event != null && entryCondition(event)
+            override val description: String = "S$id",
+        ) : State<Event, ErrorCause>("S$id") {
+
+            override fun canEnter(event: Event?): Decision<ErrorCause> = event?.let(entryCondition) ?: Decision(false)
             override fun canReenter(visits: Int): Boolean = reentryCondition(visits)
             override fun canExit(visits: Int): Boolean = exitCondition(visits)
 
             override fun hashCode(): Int = id.hashCode()
             override fun equals(other: Any?): Boolean {
                 if (this === other) return true
-                return other is Intermediate<*> && id == other.id
+                return other is Intermediate<*, *> && id == other.id
             }
         }
     }
 
     /** Models the number of times a given state has been visited for a possible path of execution */
-    private data class StateVisitCount<in Event : Any>(val state: State<Event>, val visits: Int) {
+    private data class StateVisitCount<Event : Any, ErrorCause : Any>(val state: State<Event, ErrorCause>, val visits: Int) {
         override fun toString(): String = "${state.debugId}:$visits"
     }
 
-    private fun Set<StateVisitCount<Event>>.transition(event: Event?, eventDebugString: String? = null): Set<StateVisitCount<Event>> {
-        val newStates = mutableSetOf<StateVisitCount<Event>>()
+    /** Models reasons why a transition cannot be made */
+    internal sealed class InvalidTransition<Event : Any> {
+        data class CannotEnterState<Event : Any, ErrorCause : Any>(val toState: State<Event, ErrorCause>, val reason: ErrorCause? = null) : InvalidTransition<Event>()
+        data class CannotExitState<Event : Any, ErrorCause : Any>(val fromState: State<Event, ErrorCause>) : InvalidTransition<Event>()
+        data class CannotReenterState<Event : Any, ErrorCause : Any>(val state: State<Event, ErrorCause>) : InvalidTransition<Event>()
+    }
 
-        // Cache the results of testing the entry conditions for states so that we aren't duplicating any work.
-        val entryConditionCache = mutableMapOf<State<Event>, Boolean>()
+    /** Models the result of one pass of transitions */
+    private sealed class TransitionsResult<Event : Any> {
+        class StateSet<Event : Any, ErrorCause : Any>(val states: Set<StateVisitCount<Event, ErrorCause>>) : TransitionsResult<Event>()
+        class ErrSet<Event : Any>(val eventId: Int, val errs: Set<InvalidTransition<Event>>) : TransitionsResult<Event>()
+    }
 
-        this@transition.forEach { (transitionFromState, visits) ->
-            // Cache the result of canExit, just in case someone has an expensive test here.
+    /** Describes whether the NFA matches the sequence of events. */
+    sealed class Outcome<out Event : Any> {
+        object IsMatch : Outcome<Nothing>()
+        data class IsNotMatch<Event : Any>(val eventId: Int, val reasons: Set<InvalidTransition<in Event>>) : Outcome<Event>()
+    }
+
+    /**
+     * Handles the transitions for a single event, returning an updated TransitionResult which is either a new set of
+     * states or a set of error information. Once the NFA is in an error state, it will not handle any more transitions
+     * and will only continue to propagate the error information.
+     */
+    private fun TransitionsResult<in Event>.transition(idx: Int, event: Event?, debug: Boolean = false): TransitionsResult<in Event> {
+        if (this !is TransitionsResult.StateSet<*, *>) return this
+
+        val newStates = mutableSetOf<StateVisitCount<Event, ErrorCause>>()
+        val invalidTransitions = mutableSetOf<InvalidTransition<Event>>()
+
+        // Cache the results of testing the entry conditions for states so that we aren't duplicating any work
+        // when there are multiple visit counts for the same state.
+        val entryConditionCache = mutableMapOf<State<Event, ErrorCause>, State.Decision<ErrorCause>>()
+
+        this@transition.states.forEach { (transitionFromState, visits) ->
+            transitionFromState as State<Event, ErrorCause>
             val canExit = transitionFromState.canExit(visits)
 
             transitions[transitionFromState]?.forEach { transitionToState ->
-                if (transitionFromState == transitionToState) {
-                    if (transitionToState.canReenter(visits + 1)) {
-                        // Can we enter this same state one more time?
-                        val canEnter = entryConditionCache.getOrPut(transitionToState) { transitionToState.canEnter(event) }
-                        if (canEnter) newStates.add(StateVisitCount(transitionToState, visits + 1))
-                    }
-                } else if (canExit) {
-                    // Can we exit the current state yet, and if so, can we enter the "to" state?
-                    val canEnter = entryConditionCache.getOrPut(transitionToState) { transitionToState.canEnter(event) }
-                    if (canEnter) newStates.add(StateVisitCount(transitionToState, 1))
+                val (canEnter, details) = entryConditionCache.getOrPut(transitionToState) { transitionToState.canEnter(event) }
+                val isLoop = transitionFromState == transitionToState
+                val canVisitAgain = transitionToState.canReenter(visits + 1)
+
+                if (isLoop) when {
+                    !canEnter && canVisitAgain -> invalidTransitions.add(InvalidTransition.CannotEnterState(transitionToState, details))
+                    !canVisitAgain -> invalidTransitions.add(InvalidTransition.CannotReenterState(transitionToState))
+                    else -> newStates.add(StateVisitCount(transitionToState, visits + 1))
+                } else when {
+                    !canExit -> invalidTransitions.add(InvalidTransition.CannotExitState(transitionFromState))
+                    !canEnter -> invalidTransitions.add(InvalidTransition.CannotEnterState(transitionToState, details))
+                    else -> newStates.add(StateVisitCount(transitionToState, 1))
                 }
             }
         }
-        eventDebugString?.let { println("${it.padStart(4)} : $newStates") }
-        return newStates.toSet()
+
+        return if (newStates.isNotEmpty()) {
+            TransitionsResult.StateSet(newStates)
+        } else {
+            TransitionsResult.ErrSet(idx, invalidTransitions)
+        }.also {
+            if (debug) println("${idx.toString().padStart(4)} : ${it.debugString()}")
+        }
     }
 
     /**
      * Tests if a stream of [Event] is recognized by this state machine.
      */
-    fun matches(events: Iterable<Event>, debug: Boolean = false): Boolean {
+    fun matches(events: Iterable<Event>, debug: Boolean = false): Outcome<Event> {
         if (debug) {
             println()
             println(transitions.entries.joinToString("\n") { (k, v) -> "${"$k".padEnd(3)} -> $v" })
             println("Transitions for input: $events")
-            println("     : $INITIAL_STATE")
+            println("     : ${INITIAL_STATE.debugString()}")
         }
-        return events.foldIndexed(INITIAL_STATE) { idx, states, event -> states.transition(event, if (debug) "$idx" else null) }
-            .transition(END_OF_STREAM_EVENT, if (debug) "END" else null)
-            .any { (state, _) -> state == State.Final }
+        return events.foldIndexed(INITIAL_STATE) { idx, states, event -> states.transition(idx, event, debug) }
+            .transition(events.count(), END_OF_STREAM_EVENT, debug)
+            .let {
+                when (it) {
+                    is TransitionsResult.StateSet<*, *> -> Outcome.IsMatch
+                    is TransitionsResult.ErrSet -> Outcome.IsNotMatch(it.eventId, it.errs)
+                }
+            }
+    }
+
+    /**
+     * Helper function to print debug info for state transitions
+     */
+    private fun TransitionsResult<*>.debugString() = when (this) {
+        is TransitionsResult.StateSet<*, *> -> states.toString()
+        is TransitionsResult.ErrSet -> {
+            errs.map {
+                when (it) {
+                    is InvalidTransition.CannotEnterState<*, *> -> "CannotEnterState(${it.toState})"
+                    is InvalidTransition.CannotExitState<*, *> -> "CannotExitState(${it.fromState})"
+                    is InvalidTransition.CannotReenterState<*, *> -> "CannotReenterState(${it.state})"
+                }
+            }.toString()
+        }
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
@@ -22,11 +22,13 @@ import com.amazon.ion.IonValue
 import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Violation
+import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.TypeReference
 import com.amazon.ionschema.internal.util.IntRange
 import com.amazon.ionschema.internal.util.islRequire
 import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.schemaTypeName
 
 /**
  * Implements the ordered_element constraint.
@@ -39,20 +41,21 @@ internal class OrderedElements(
     private val schema: Schema
 ) : ConstraintBase(ion) {
 
-    private val nfa: NFA<IonValue> = run {
+    private val nfa: NFA<IonValue, Violation> = run {
         islRequireIonTypeNotNull<IonList>(ion) { "Invalid ordered_elements constraint: $ion" }
         if (schema.ionSchemaLanguageVersion >= v2_0) {
             islRequire(ion.typeAnnotations.isEmpty()) { "ordered_elements list may not be annotated. Found: $ion" }
         }
 
         val stateBuilder = OrderedElementsNfaStatesBuilder()
-        ion.forEach {
+        ion.forEachIndexed { idx, it ->
             val occursRange = IntRange.toIntRange((it as? IonStruct)?.get("occurs")) ?: IntRange.REQUIRED
             val typeRef = TypeReference.create(it, schema, variablyOccurring = true)
             stateBuilder.addState(
                 min = occursRange.lower,
                 max = occursRange.upper,
-                matches = { typeRef().isValid(it) }
+                matches = { Violation().let { v -> typeRef().validate(it, v); NFA.State.Decision(v.isValid(), v.singleOrNull()) } },
+                description = "<ELEMENT $idx> $it",
             )
         }
         NFA(stateBuilder.build())
@@ -65,14 +68,58 @@ internal class OrderedElements(
     // Visible for testing
     internal fun validate(value: IonValue, issues: Violations, debug: Boolean) {
         validateAs<IonSequence>(value, issues) { v ->
-            if (!nfa.matches(v, debug)) {
+            val outcome = nfa.matches(v, debug)
+
+            if (outcome is NFA.Outcome.IsNotMatch<*>) {
                 issues.add(
                     Violation(
                         ion, "ordered_elements_mismatch",
                         "one or more ordered elements don't match specification"
-                    )
+                    ).apply { add(buildViolationForValue(v, outcome.eventId, outcome.reasons)) }
                 )
             }
         }
+    }
+
+    /**
+     * Builds a violation that describes the element of the sequence where it was discovered that the data was invalid.
+     * Note that this is not necessarily the "reason" the data is invalid. For example, if you expect letters in
+     * alphabetical order, then (a c f r n p t) is invalid. The _fact_ that it is invalid will be detected at the letter
+     * 'n', but it's debatable whether 'n' is the problem or if the problem is the the 'r' that precedes it. That
+     * distinction is undecidable unless we can assign meaning to incorrect data, which is outside the scope of Ion Schema.
+     */
+    private fun buildViolationForValue(value: IonSequence, idx: Int, reasons: Set<NFA.InvalidTransition<out Any>>): ViolationChild {
+
+        val isEndOfSequenceEvent = idx == value.size
+        val valueViolation = ViolationChild(
+            index = if (isEndOfSequenceEvent) null else idx,
+            fieldName = if (isEndOfSequenceEvent) "<END OF ${value.type.schemaTypeName().toUpperCase()}>" else null,
+            value = value.getOrNull(idx)
+        )
+
+        val describe: NFA.State<*, *>.() -> String = {
+            when (this) {
+                NFA.State.Final -> "<END OF ${value.type.schemaTypeName().toUpperCase()}>"
+                else -> description
+            }
+        }
+
+        reasons.forEach {
+            val message = when (it) {
+                is NFA.InvalidTransition.CannotEnterState<*, *> -> "does not match: ${it.toState.describe()}"
+                is NFA.InvalidTransition.CannotExitState<*, *> -> "min occurs not reached: ${it.fromState.describe()}"
+                is NFA.InvalidTransition.CannotReenterState<*, *> -> "max occurs already reached: ${it.state.describe()}"
+            }
+            valueViolation.add(
+                Violation(message = message).apply {
+                    if (it is NFA.InvalidTransition.CannotEnterState<*, *> && it.reason is Violations) {
+                        it.reason.violations.forEach { this.add(it) }
+                        it.reason.children.forEach { this.add(it) }
+                    }
+                }
+            )
+        }
+
+        return valueViolation
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
@@ -16,6 +16,7 @@
 package com.amazon.ionschema.internal.util
 
 import com.amazon.ion.IonStruct
+import com.amazon.ion.IonType
 import com.amazon.ion.IonValue
 
 /**
@@ -43,4 +44,13 @@ internal fun IonStruct.getFields(fieldName: String): List<IonValue> {
 internal fun <T : IonValue> T.markReadOnly(): T {
     this.makeReadOnly()
     return this
+}
+
+/**
+ * Returns the Ion Schema type name for an IonType.
+ * TLDR; "DATAGRAM" is "document" and every other name is simply converted to lowercase.
+ */
+internal fun IonType.schemaTypeName() = when (this) {
+    IonType.DATAGRAM -> "document"
+    else -> this.toString().toLowerCase()
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #110 

**Description of changes:**

This adds better messages for the ordered elements constraint. It's impossible to fully determine what the "cause" of the validation failure is because that requires a better understanding of the data than what is in scope for Ion Schema, and it seems like it also requires some amount of "intuition".

For example, if you expect letters in alphabetical order, then `(a b d c)` is invalid. The _fact_ that it is invalid will be detected at the letter 'c', but it's not really decidable whether the problem is the 'c' or the 'd' that precedes it.

The strategy I've chosen for the violation messages is to report all violations for the first element that does not match any possible "branches" in the NFA.  See `OrderedElementsTest.kt` for some examples of what this looks like.

In order to make this possible, I refactored the NFA class so that it state transitions can return Violations instead of just `true`/`false`, and I had to update the `OrderedElements` constraint to interpret the new outcome data from the NFA.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
