### PR TITLE
Fixes import resolution for cyclical import graphs

### DIFF
--- a/ion-schema/build.gradle
+++ b/ion-schema/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+  testImplementation 'io.mockk:mockk:1.13.3'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaVersion.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaVersion.kt
@@ -16,6 +16,9 @@
 package com.amazon.ionschema
 
 import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 enum class IonSchemaVersion(val symbolText: String) {
     v1_0("\$ion_schema_1_0"),
@@ -24,7 +27,17 @@ enum class IonSchemaVersion(val symbolText: String) {
     companion object {
         internal fun fromIonSymbolOrNull(symbol: IonSymbol): IonSchemaVersion? = values().singleOrNull { it.symbolText == symbol.stringValue() }
 
+        /**
+         * Tests if the IonValue is a value that is reserved for version markers, as per
+         * [ISL Versioning](https://amazon-ion.github.io/ion-schema/docs/isl-versioning#ion-schema-version-markers).
+         */
+        @OptIn(ExperimentalContracts::class)
+        internal fun isVersionMarker(value: IonValue): Boolean {
+            contract { returns(true) implies (value is IonSymbol) }
+            return value is IonSymbol && !value.isNullValue && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())
+        }
+
         @JvmStatic
-        internal val VERSION_MARKER_REGEX = Regex("^\\\$ion_schema_\\d.*")
+        private val VERSION_MARKER_REGEX = Regex("^\\\$ion_schema_\\d.*")
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactory.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactory.kt
@@ -32,5 +32,5 @@ internal interface ConstraintFactory {
      * @param[ion] IonValue identifying the constraint to construct as well as its configuration
      * @param[schema] passed to constraints that require a schema object
      */
-    fun constraintFor(ion: IonValue, schema: SchemaInternal): Constraint
+    fun constraintFor(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager): Constraint
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.Violations
+
+/**
+ * Represents a [TypeInternal] that is known to be declared in a schema document, but the [TypeInternal] instance has
+ * not necessarily been created yet. A [DeferredReference] can be resolved or unresolved. When it is unresolved,
+ * it is unknown whether the referred [TypeInternal] instance exists. When it is resolved, this [DeferredReference]
+ * is able to return and/or delegate validation to the referred [TypeInternal] instance.
+ */
+internal interface DeferredReference : TypeInternal {
+    override val isl: IonSymbol
+    override val name: String
+        get() = isl.stringValue()
+
+    /**
+     * Returns the [TypeInternal] that this [DeferredReference] resolves to, or `null` if it cannot be resolved.
+     */
+    fun resolve(): TypeInternal
+
+    /**
+     * Returns true if this [DeferredReference] is already resolved.
+     */
+    fun isResolved(): Boolean
+
+    override fun getBaseType(): TypeBuiltin = resolve().getBaseType()
+    override fun isValidForBaseType(value: IonValue): Boolean = resolve().isValidForBaseType(value)
+    override fun validate(value: IonValue, issues: Violations) = resolve().validate(value, issues)
+}
+
+/**
+ * An implementation of [DeferredReference] that refers to a [TypeInternal] that is declared in a [SchemaInternal]
+ * that has already been instantiated.
+ *
+ * Use this for references to other types that are in scope for the same schema that the reference is being created for.
+ */
+internal class DeferredLocalReference(
+    override val isl: IonSymbol,
+    private val schema: SchemaInternal
+) : DeferredReference {
+    override val schemaId: String? = schema.schemaId
+    private var type: TypeInternal? = null
+
+    override fun resolve(): TypeInternal {
+        return type
+            ?: schema.getType(name)?.also { type = it }
+            ?: throw InvalidSchemaException("Unable to resolve type $isl")
+    }
+    override fun isResolved(): Boolean = type != null
+}
+
+/**
+ * An implementation of [DeferredReference] that refers to a [TypeInternal] that is declared in a [SchemaInternal]
+ * that has not necessarily been instantiated yet. This class also implements [ImportedType], which means that
+ * [schemaId] is required to be non-null.
+ *
+ * Use this for references to other types that are defined in other schemas.
+ */
+internal class DeferredImportReference constructor(
+    override val isl: IonSymbol,
+    override val schemaId: String,
+    private val schemaProvider: () -> SchemaInternal
+) : DeferredReference, ImportedType {
+    override val importedFromSchemaId: String
+        get() = schemaId
+
+    private var type: TypeInternal? = null
+
+    override fun resolve(): TypeInternal {
+        return type
+            ?: schemaProvider().getType(name)?.also { type = it }
+            ?: throw InvalidSchemaException("Unable to resolve type $isl")
+    }
+    override fun isResolved(): Boolean = type != null
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReferenceManager.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReferenceManager.kt
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.Schema
+import java.util.LinkedList
+import java.util.Queue
+
+/**
+ * A single-use "session" for creating, tracking, and resolving deferred references _for multiple [Schema]_.
+ *
+ * A [DeferredReferenceManager] allows you to create [DeferredReference] instances, and it keeps track of any
+ * [DeferredReference] instances that it creates. When this [DeferredReferenceManager] is closed, it attempts to
+ * resolve all of the [DeferredReference]. If any cannot be resolved, it throws an [InvalidSchemaException] listing
+ * the types that cannot be resolved.
+ *
+ * In addition, a schema can be registered with the [DeferredReferenceManager] as being dependent on the outcome of
+ * resolving the deferred references. See [registerDependentSchema] for details.
+ *
+ * Once a [DeferredReferenceManager] instance has been closed, you cannot use that instance to create any new references
+ * nor can you register any dependent schemas, and the instance should be discarded. Attempting to perform any operation
+ * once closed will result in an [IllegalStateException] being thrown.
+ */
+internal class DeferredReferenceManager(
+    private val loadSchemaFn: (DeferredReferenceManager, String) -> SchemaInternal,
+    private val unloadSchema: (String) -> Unit,
+    private val isSchemaAlreadyLoaded: (String) -> Boolean,
+) {
+
+    private val deferredTypeReferences: Queue<DeferredReference> = LinkedList()
+    private val dependentSchemas = mutableSetOf<String>()
+    private var isClosed = false
+
+    /**
+     * Creates a [DeferredLocalReference] for a type with name [typeId] that is in scope for the given [schema].
+     */
+    fun createDeferredLocalReference(schema: SchemaInternal, typeId: IonSymbol): DeferredLocalReference {
+        if (isClosed) throw IllegalStateException("Cannot create a new reference using a closed DeferredReferenceManager")
+        val ref = DeferredLocalReference(typeId, schema)
+        deferredTypeReferences.add(ref)
+        return ref
+    }
+
+    /**
+     * Creates an [DeferredImportReference] for a type with name [typeId] that is declared in [schemaId].
+     */
+    fun createDeferredImportReference(schemaId: String, typeId: IonSymbol): DeferredImportReference {
+        if (isClosed) throw IllegalStateException("Cannot create a new reference using a closed DeferredReferenceManager")
+        val ref = DeferredImportReference(typeId, schemaId) { loadSchemaFn(this, schemaId) }
+        deferredTypeReferences.add(ref)
+        return ref
+    }
+
+    /**
+     * Indicates that the validity of the [Schema] for the given [schemaId] depends on the outcome of this
+     * [DeferredReferenceManager]. If the [Schema] for the given [schemaId] is already loaded into the [IonSchemaSystemImpl],
+     * then this function does nothing. Otherwise, the [schemaId] is added to the list of [dependentSchemas] that will
+     * need to be invalidated if any deferred references cannot be resolved.
+     *
+     * In other words, we cannot guarantee that a schema is valid until we have validated all of its deferred references.
+     * If any references are deferred, and then later discovered to be invalid, then we must invalidate all schemas that
+     * depend on that reference—directly or indirectly. In practice, however, this class takes a safe-but-naive approach
+     * and will unload *all* schemas that are dependent on the outcome of this [DeferredReferenceManager].
+     *
+     * This function should only be called from the initializer block of a [Schema] implementation.
+     */
+    internal fun registerDependentSchema(schemaId: String) {
+        if (isClosed) throw IllegalStateException("Cannot register a dependent schema with a closed DeferredReferenceManager")
+
+        // If this function is only called from the init block of a Schema implementation (as prescribed), then it
+        // should not be possible for the given schemaId to already be loaded. However, we check anyway so that this
+        // function does not have to make assumptions about its preconditions.
+        if (isSchemaAlreadyLoaded(schemaId)) return
+
+        dependentSchemas.add(schemaId)
+    }
+
+    fun resolve() {
+        if (isClosed) throw IllegalStateException("Cannot call resolve() on a closed DeferredReferenceManager")
+        try {
+
+            // NOTE: we must use a loop rather than an iterator/stream/sequence since more items can be
+            // added to the queue as a side effect of resolving a deferred type reference.
+            while (deferredTypeReferences.isNotEmpty()) {
+                deferredTypeReferences.poll().resolve()
+            }
+        } catch (e: Exception) {
+            // If anything goes wrong, evict all possibly bad schemas that might have been cached
+            dependentSchemas.forEach { unloadSchema(it) }
+            throw e
+        } finally {
+            isClosed = true
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ImportImpl.kt
@@ -21,14 +21,23 @@ import com.amazon.ionschema.Type
 
 /**
  * Implementation of [Import] for all user-provided ISL.
+ *
+ * This is no longer used to support any of the internal functionality of Ion Schema Kotlin. It exists only for the
+ * [Schema.getImports] and [Schema.getImport] functions.
+ *
+ * Do not call any functions of this class (directly or indirectly) from within the init block of _any_ [Schema]
+ * implementation. If you do, the call may fail, depending on the order that schema imports are resolved, which is not
+ * guaranteed to be stable.
+ *
+ * This class (and [Import]) should be removed in v2.0.0 in favor of a map of schemaId to [Type] (or similar).
  */
 internal class ImportImpl(
     override val id: String,
-    private val schema: Schema,
+    private val schemaProvider: () -> Schema,
     private val types: Map<String, Type>
 ) : Import {
 
-    override fun getSchema() = schema
+    override fun getSchema() = schemaProvider()
 
     override fun getType(name: String) = types[name]
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -44,9 +44,6 @@ internal class IonSchemaSystemImpl(
         loadSchemaIslForId = this::loadSchemaIslForId
     )
 
-    // Set to be used to detect cycle in import dependencies
-    private val schemaImportSet: MutableSet<String> = mutableSetOf()
-
     /**
      * Loads the Ion content for a given schema ID.
      */
@@ -173,8 +170,6 @@ internal class IonSchemaSystemImpl(
     internal fun isConstraint(name: String, schema: SchemaInternal) = constraintFactory.isConstraint(name, schema.ionSchemaLanguageVersion)
 
     internal fun constraintFor(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager) = constraintFactory.constraintFor(ion, schema, referenceManager)
-
-    internal fun getSchemaImportSet() = schemaImportSet
 
     internal fun emitWarning(lazyWarning: () -> String) {
         warnCallback.invoke(lazyWarning)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -15,7 +15,6 @@
 
 package com.amazon.ionschema.internal
 
-import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonSystem
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Authority
@@ -74,7 +73,7 @@ internal class IonSchemaSystemImpl(
         val isl = schemaIterator.use {
             it.asSequence()
                 .onEach {
-                    if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                    if (IonSchemaVersion.isVersionMarker(it)) {
                         version = IonSchemaVersion.fromIonSymbolOrNull(it)
                             ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                     }
@@ -100,7 +99,7 @@ internal class IonSchemaSystemImpl(
         var version = IonSchemaVersion.v1_0
         val islList = isl.asSequence()
             .onEach {
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     version = IonSchemaVersion.fromIonSymbolOrNull(it) ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                 }
             }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
@@ -25,7 +25,7 @@ internal class SchemaContent(val isl: List<IonValue>) {
         var version: IonSchemaVersion = IonSchemaVersion.v1_0
         declaredTypes = isl
             .onEach {
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     version = IonSchemaVersion.fromIonSymbolOrNull(it)
                         ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
@@ -1,0 +1,38 @@
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.getIslRequiredField
+
+/**
+ * A wrapper class for a stream of IonValue that is expected to be an Ion Schema document.
+ *
+ * The purpose of this class is similar to a C header file—so that we can know about all the declared types in a schema
+ * document before we've fully loaded the schema document into the schema system. This is essential for being able to
+ * resolve cyclical dependencies. See also [Forward Declaration](https://en.wikipedia.org/wiki/Forward_declaration).
+ *
+ * This class performs some processing in its initialization block in order to determine the Ion Schema version and
+ * the names of all the types declared by the schema document, but it does not perform any syntactic or semantic
+ * validation of the schema document.
+ */
+internal class SchemaContent(val isl: List<IonValue>) {
+    val version: IonSchemaVersion
+    val declaredTypes: List<IonSymbol>
+    init {
+        var version: IonSchemaVersion = IonSchemaVersion.v1_0
+        declaredTypes = isl
+            .onEach {
+                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                    version = IonSchemaVersion.fromIonSymbolOrNull(it)
+                        ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
+                }
+            }
+            .filterIsInstance<IonStruct>()
+            .filter { it.hasTypeAnnotation("type") }
+            .map { it.getIslRequiredField("name") }
+        this.version = version
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+
+/**
+ * A class that caches the uninterpreted content of a Schema document. This enables us to determine which types are
+ * declared in a schema prior to having a [SchemaInternal] instance for the schema, which is especially useful for
+ * checking the validity of a type reference without having to resolve the type reference to a [TypeInternal] instance.
+ */
+internal class SchemaContentCache constructor(
+    private val loader: (String) -> SchemaContent,
+    private val delegate: MutableMap<String, SchemaContent> = mutableMapOf(),
+) {
+    constructor(
+        /**
+         * A function to look up a schema that has already been loaded by the [IonSchemaSystemImpl] so that we can ensure
+         * that this [SchemaContentCache] has a consistent view of a schema, and so that it doesn't do unnecessary work to
+         * load a schema document that has already been loaded e.g. from disk.
+         */
+        getPreloadedSchemaIsl: (String) -> List<IonValue>?,
+        /**
+         * A function to load the schema document content for a schemaId (most likely by using authorities).
+         */
+        loadSchemaIslForId: (String) -> List<IonValue>
+    ) : this({ SchemaContent(getPreloadedSchemaIsl(it) ?: loadSchemaIslForId(it)) })
+
+    /**
+     * Returns the [SchemaContent] for the given [schemaId]. Throws an [InvalidSchemaException] if the schema is not
+     * found or is malformed Ion.
+     */
+    fun getSchemaContent(schemaId: String): SchemaContent {
+        return delegate.getOrPut(schemaId) {
+            try {
+                loader(schemaId)
+            } catch (e: Exception) {
+                throw InvalidSchemaException("Unable to load schema $schemaId: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Checks if a schema exists for the given schema ID. Does not guarantee that the schema is valid ISL—just that
+     * there is some Ion that can be found using this schema ID.
+     *
+     * Has the side effect of loading the content for the given [schemaId] if that content has not already been loaded
+     * into this instance of [SchemaContentCache].
+     */
+    fun doesSchemaExist(schemaId: String): Boolean {
+        return runCatching { getSchemaContent(schemaId) }.isSuccess
+    }
+
+    /**
+     * Checks if the schema document for the given [schemaId] has a named type definition with the name [typeId]. This
+     * does not guarantee that the type definition or the schema document are valid—only that a `type::{ name: ... }`
+     * exists in the schema document for the given [typeId].
+     *
+     * Has the side effect of loading the content for the given [schemaId] if that content has not already been loaded
+     * into this instance of [SchemaContentCache].
+     */
+    fun doesSchemaDeclareType(schemaId: String, typeId: IonSymbol): Boolean {
+        return runCatching { typeId in getSchemaContent(schemaId).declaredTypes }.getOrElse { false }
+    }
+
+    /**
+     * Removes a schema from this cache.
+     */
+    fun invalidate(schemaId: String) {
+        delegate.remove(schemaId)
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
@@ -43,12 +43,14 @@ internal class SchemaCore(
             .associateBy({ it.stringValue() }, { newType(it) })
             .toMutableMap()
 
-        ION.iterate(ADDITIONAL_TYPE_DEFS)
-            .asSequence()
-            .map { (it as IonStruct).first() }
-            .forEach {
-                typeMap.put(it.fieldName, TypeBuiltinImpl(it as IonStruct, this))
-            }
+        schemaSystem.usingReferenceManager { referenceManager ->
+            ION.iterate(ADDITIONAL_TYPE_DEFS)
+                .asSequence()
+                .map { (it as IonStruct).first() }
+                .forEach {
+                    typeMap.put(it.fieldName, TypeBuiltinImpl(it as IonStruct, this, referenceManager))
+                }
+        }
 
         isl = ION.newDatagram().markReadOnly()
     }
@@ -79,7 +81,6 @@ internal class SchemaCore(
     override fun newType(isl: String) = throw UnsupportedOperationException()
     override fun newType(isl: IonStruct) = throw UnsupportedOperationException()
     override fun plusType(type: Type) = throw UnsupportedOperationException()
-    override fun addDeferredType(typeRef: TypeReferenceDeferred) = throw UnsupportedOperationException()
 }
 
 private const val CORE_TYPES =

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
@@ -78,7 +78,7 @@ internal class SchemaImpl_1_0 private constructor(
 
                 dgIsl.add(it.clone())
 
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     // This implementation only supports Ion Schema 1.0
                     if (it.stringValue() != "\$ion_schema_1_0") {
                         throw InvalidSchemaException("Unsupported Ion Schema version: ${it.stringValue()}")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
@@ -23,6 +23,7 @@ import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Import
 import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaException
 import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
@@ -84,7 +85,7 @@ internal class SchemaImpl_1_0 private constructor(
                         throw InvalidSchemaException("Unsupported Ion Schema version: ${it.stringValue()}")
                     }
                 } else if (it.hasTypeAnnotation("schema_header")) {
-                    importsMap = loadHeader(types, it as IonStruct)
+                    importsMap = loadHeader(types, it as IonStruct, referenceManager)
                     foundHeader = true
                 } else if (!foundFooter && it.hasTypeAnnotation("type") && it is IonStruct) {
                     val newType = TypeImpl(it, this, referenceManager)
@@ -119,7 +120,7 @@ internal class SchemaImpl_1_0 private constructor(
         }
     }
 
-    private class SchemaAndTypeImports(val id: String, val schema: Schema) {
+    private class SchemaAndTypeImports(val id: String, val schema: () -> Schema) {
         var types: MutableMap<String, TypeInternal> = mutableMapOf()
 
         fun addType(name: String, type: TypeInternal) {
@@ -136,78 +137,87 @@ internal class SchemaImpl_1_0 private constructor(
 
     private fun loadHeader(
         typeMap: MutableMap<String, TypeInternal>,
-        header: IonStruct
+        header: IonStruct,
+        referenceManager: DeferredReferenceManager
     ): Map<String, Import> {
 
         val importsMap = mutableMapOf<String, SchemaAndTypeImports>()
-        val importSet: MutableSet<String> = schemaSystem.getSchemaImportSet()
         val allowTransitiveImports = schemaSystem.getParam(IonSchemaSystemImpl.Param.ALLOW_TRANSITIVE_IMPORTS)
 
         (header.get("imports") as? IonList)
             ?.filterIsInstance<IonStruct>()
             ?.forEach {
-                val childImportId = it["id"] as IonText
+                val childImportId = (it["id"] as IonText).stringValue()
                 val alias = it["as"] as? IonSymbol
-                // if importSet has an import with this id then do not load schema again to break the cycle.
-                if (!importSet.contains(childImportId.stringValue())) {
-                    var parentImportId = schemaId ?: ""
 
-                    // if Schema is importing itself then throw error
-                    if (parentImportId.equals(childImportId.stringValue())) {
-                        throw InvalidSchemaException("Schema can not import itself.")
-                    }
+                // if Schema is importing itself then throw error
+                if (schemaId == childImportId) {
+                    throw InvalidSchemaException("Schema can not import itself.")
+                }
 
-                    // add parent and current schema to importSet and continue loading current schema
-                    importSet.add(parentImportId)
-                    importSet.add(childImportId.stringValue())
-                    val importedSchema = schemaSystem.loadSchema(childImportId.stringValue())
-                    importSet.remove(childImportId.stringValue())
-                    importSet.remove(parentImportId)
-
-                    val schemaAndTypes = importsMap.getOrPut(childImportId.stringValue()) {
-                        SchemaAndTypeImports(childImportId.stringValue(), importedSchema)
-                    }
-
-                    val typeName = (it["type"] as? IonSymbol)?.stringValue()
-                    if (typeName != null) {
-                        var importedType = importedSchema.getDeclaredType(typeName)
-                            ?.toImportedType(childImportId.stringValue())
-
-                        if (importedType == null && allowTransitiveImports) {
-                            importedType = importedSchema.getType(typeName)
-                                ?.toImportedType(childImportId.stringValue())
-                                ?.also { type ->
-                                    schemaSystem.emitWarning {
-                                        warnInvalidTransitiveImport(type, this.schemaId)
-                                    }
-                                }
-                        }
-
-                        importedType ?: throw InvalidSchemaException("Schema $childImportId doesn't contain a type named '$typeName'")
-
-                        if (alias != null) {
-                            importedType = TypeAliased(alias, importedType)
-                        }
-                        addType(typeMap, importedType)
-                        schemaAndTypes.addType(alias?.stringValue() ?: typeName, importedType)
-                    } else {
-                        val typesToAdd =
-                            if (allowTransitiveImports)
-                                importedSchema.getTypes()
-                            else
-                                importedSchema.getDeclaredTypes()
-
-                        typesToAdd.asSequence()
-                            .map { type -> type.toImportedType(childImportId.stringValue()) }
-                            .forEach { type ->
-                                addType(typeMap, type)
-                                schemaAndTypes.addType(type.name, type)
-                            }
+                val importedSchemaFn = {
+                    try {
+                        schemaSystem.loadSchema(childImportId)
+                    } catch (e: StackOverflowError) {
+                        throw IonSchemaException(
+                            """
+                            IonSchemaSystem encountered a circular import graph that cannot be resolved because transitive imports are enabled.
+                            You can resolve this in one of the following ways (listed in order of preference):
+                              1) Upgrade your schemas to use Ion Schema 2.0.
+                              2) Disable transitive imports using IonSchemaSystemBuilder.allowTransitiveImports(false)
+                              3) Update your schemas to import individual types rather than importing whole schemas (e.g. `{ id: "my_schema.isl", type: my_type }` instead of `{ id: "my_schema.isl" }`). 
+                            """.trimIndent()
+                        )
                     }
                 }
+
+                val schemaAndTypes = importsMap.getOrPut(childImportId) {
+                    SchemaAndTypeImports(childImportId, importedSchemaFn)
+                }
+
+                val typeField = it["type"] as? IonSymbol
+                val typeName = typeField?.stringValue()
+                if (typeName != null) {
+                    var importedType: ImportedType? = if (schemaSystem.doesSchemaDeclareType(childImportId, typeField)) {
+                        referenceManager.createDeferredImportReference(childImportId, typeField)
+                    } else {
+                        null
+                    }
+
+                    if (importedType == null && allowTransitiveImports) {
+                        importedType = importedSchemaFn().getType(typeName)
+                            ?.toImportedType(childImportId)
+                            ?.also { type ->
+                                schemaSystem.emitWarning {
+                                    warnInvalidTransitiveImport(type, this.schemaId)
+                                }
+                            }
+                    }
+
+                    importedType ?: throw InvalidSchemaException("Schema $childImportId doesn't contain a type named '$typeName'")
+
+                    if (alias != null) {
+                        importedType = TypeAliased(alias, importedType)
+                    }
+                    addType(typeMap, importedType)
+                    schemaAndTypes.addType(alias?.stringValue() ?: typeName, importedType)
+                } else {
+                    val typesToAdd =
+                        if (allowTransitiveImports)
+                            importedSchemaFn().getTypes().asSequence().toList()
+                        else
+                            schemaSystem.listDeclaredTypes(childImportId).map { referenceManager.createDeferredImportReference(childImportId, it) }
+
+                    typesToAdd.map { type -> type.toImportedType(childImportId) }
+                        .forEach { type ->
+                            addType(typeMap, type)
+                            schemaAndTypes.addType(type.name, type)
+                        }
+                }
             }
+
         return importsMap.mapValues {
-            ImportImpl(it.value.id, { it.value.schema }, it.value.types)
+            ImportImpl(it.value.id, it.value.schema, it.value.types)
         }
     }
 
@@ -227,7 +237,8 @@ internal class SchemaImpl_1_0 private constructor(
     }
 
     private fun addType(typeMap: MutableMap<String, TypeInternal>, type: TypeInternal) {
-        validateType(type)
+        if (type !is ImportedType) validateType(type)
+
         getType(type.name)?.let {
             if (it.schemaId != type.schemaId || it.isl != type.isl) {
                 throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
@@ -303,6 +314,8 @@ internal class SchemaImpl_1_0 private constructor(
      * log a transitive import warning every time it is used for validation.
      */
     private fun TypeInternal.toImportedType(importedFromSchemaId: String): ImportedType {
+        if (this is ImportedType && !schemaSystem.getParam(IonSchemaSystemImpl.Param.ALLOW_TRANSITIVE_IMPORTS)) return this
+
         return object : ImportedType, TypeInternal by this {
             override fun validate(value: IonValue, issues: Violations) {
                 if (importedFromSchemaId != schemaId) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -107,7 +107,7 @@ internal class SchemaImpl_2_0 private constructor(
                 dgIsl.add(it.clone())
 
                 when {
-                    isVersionMarker(it) -> {
+                    IonSchemaVersion.isVersionMarker(it) -> {
                         islRequire(it.stringValue() == IonSchemaVersion.v2_0.symbolText) { "Unsupported Ion Schema version: $it" }
                         islRequire(!foundVersionMarker) { "Only one Ion Schema version marker is allowed in a schema document." }
                         islRequire(!foundHeader && !foundAnyType && !foundFooter) { "Ion Schema version marker must come before any header, types, and footer." }
@@ -184,7 +184,7 @@ internal class SchemaImpl_2_0 private constructor(
      * See https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#open-content
      */
     private fun isTopLevelOpenContent(value: IonValue): Boolean {
-        if (value is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())) {
+        if (IonSchemaVersion.isVersionMarker(value)) {
             return false
         }
         if (value.typeAnnotations.any { IonSchema_2_0.RESERVED_WORDS_REGEX.matches(it) }) {
@@ -203,12 +203,6 @@ internal class SchemaImpl_2_0 private constructor(
     private fun isFooter(value: IonValue): Boolean {
         contract { returns(true) implies (value is IonStruct) }
         return value is IonStruct && !value.isNullValue && arrayOf("schema_footer").contentDeepEquals(value.typeAnnotations)
-    }
-
-    @OptIn(ExperimentalContracts::class)
-    private fun isVersionMarker(value: IonValue): Boolean {
-        contract { returns(true) implies (value is IonSymbol) }
-        return value is IonSymbol && !value.isNullValue && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())
     }
 
     @OptIn(ExperimentalContracts::class)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaInternal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaInternal.kt
@@ -26,8 +26,6 @@ import com.amazon.ionschema.Schema
 internal interface SchemaInternal : Schema {
     val schemaId: String?
 
-    fun addDeferredType(typeRef: TypeReferenceDeferred)
-
     /**
      * The in-scope types for a schema consist of the ISL core types, any types declared in that schema, and any types
      * that are imported to the schema. This function is intended for internal use only in order to detect naming

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeBuiltinImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeBuiltinImpl.kt
@@ -31,8 +31,8 @@ internal class TypeBuiltinImpl private constructor(
     private val delegate: TypeInternal
 ) : TypeInternal by delegate, ConstraintBase(ion), TypeBuiltin {
 
-    constructor (ionStruct: IonStruct, schema: SchemaInternal) :
-        this(ionStruct, TypeImpl(ionStruct, schema, addDefaultTypeConstraint = false))
+    constructor (ionStruct: IonStruct, schema: SchemaInternal, referenceManager: DeferredReferenceManager) :
+        this(ionStruct, TypeImpl(ionStruct, schema, referenceManager, addDefaultTypeConstraint = false))
 
     override val name: String = ion.fieldName
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
@@ -33,6 +33,7 @@ import com.amazon.ionschema.internal.util.markReadOnly
 internal class TypeImpl(
     private val ionStruct: IonStruct,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
     addDefaultTypeConstraint: Boolean = true
 ) : TypeInternal, ConstraintBase(ionStruct) {
 
@@ -50,13 +51,13 @@ internal class TypeImpl(
         constraints = ionStruct.asSequence()
             .filter { it.fieldName == null || schema.getSchemaSystem().isConstraint(it.fieldName, schema) }
             .onEach { if (it.fieldName == "type") { foundTypeConstraint = true } }
-            .map { (schema.getSchemaSystem()).constraintFor(it, schema) }
+            .map { schema.getSchemaSystem().constraintFor(it, schema, referenceManager) }
             .toMutableList()
 
         if (schema.ionSchemaLanguageVersion == IonSchemaVersion.v1_0) {
             if (!foundTypeConstraint && addDefaultTypeConstraint) {
                 // default type for ISL 1.0 is 'any':
-                constraints.add(TypeReference.create(ANY, schema)())
+                constraints.add(TypeReference.create(ANY, schema, referenceManager)())
             }
         }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInline.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInline.kt
@@ -29,8 +29,8 @@ internal class TypeInline private constructor (
     private val type: TypeInternal
 ) : ConstraintBase(ion), TypeInternal by type {
 
-    constructor(ionStruct: IonStruct, schema: SchemaInternal) :
-        this(ionStruct, TypeImpl(ionStruct, schema))
+    constructor(ionStruct: IonStruct, schema: SchemaInternal, referenceManager: DeferredReferenceManager) :
+        this(ionStruct, TypeImpl(ionStruct, schema, referenceManager))
 
     override val name = type.name
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeReference.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeReference.kt
@@ -21,13 +21,11 @@ import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.IonSchemaVersion
-import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.util.IonSchema_2_0
-import com.amazon.ionschema.internal.util.getIslOptionalField
 import com.amazon.ionschema.internal.util.getIslRequiredField
 import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireNotNull
 import com.amazon.ionschema.internal.util.islRequireOnlyExpectedFieldNames
-import com.amazon.ionschema.internal.util.markReadOnly
 
 /**
  * Provides a factory method that translates an ISL type reference into a function
@@ -44,6 +42,7 @@ internal class TypeReference private constructor() {
         fun create(
             ion: IonValue,
             schema: SchemaInternal,
+            referenceManager: DeferredReferenceManager,
             isField: Boolean = false,
             variablyOccurring: Boolean = false,
             isNamePermitted: Boolean = false,
@@ -72,53 +71,68 @@ internal class TypeReference private constructor() {
                             "Illegal 'name' field in type reference: $ion"
                         }
                     }
-                    handleStruct(ion, schema, isField)
+                    if (ion.containsKey("id")) {
+                        handleInlineImport(ion, schema, referenceManager)
+                    } else {
+                        handleInlineTypeDefinition(ion, schema, referenceManager, isField)
+                    }
                 }
-                is IonSymbol -> handleSymbol(ion, schema)
+                is IonSymbol -> handleSymbol(ion, schema, referenceManager)
                 else -> throw InvalidSchemaException("Unable to resolve type reference '$ion'")
             }
         }
 
-        private fun handleStruct(ion: IonStruct, schema: SchemaInternal, isField: Boolean): () -> TypeInternal {
-            val id = ion.getIslOptionalField<IonText>("id")
+        private fun handleInlineTypeDefinition(ion: IonStruct, schema: SchemaInternal, referenceManager: DeferredReferenceManager, isField: Boolean): () -> TypeInternal {
             val type = when {
-                id != null -> {
-                    // import
-                    if (schema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {
-                        ion.islRequireOnlyExpectedFieldNames(IonSchema_2_0.INLINE_IMPORT_KEYWORDS)
-                        islRequire(id.stringValue() != schema.schemaId) { "A schema may not directly import itself: $ion" }
-                    }
-                    val typeName = ion.getIslRequiredField<IonSymbol>("type")
-                    val importedSchema = runCatching { schema.getSchemaSystem().loadSchema(id.stringValue()) }
-                        .getOrElse { e -> throw InvalidSchemaException("Unable to load schema '${id.stringValue()}'; ${e.message}") }
-                    importedSchema.getType(typeName.stringValue())
-                }
-                isField -> TypeImpl(ion, schema)
-                ion.size() == 1 && ion["type"] != null -> {
-                    // elide inline types defined as "{ type: X }" to TypeImpl;
-                    // this avoids creating a nested, redundant validation structure
-                    TypeImpl(ion, schema)
-                }
-                else -> TypeInline(ion, schema)
+                isField -> TypeImpl(ion, schema, referenceManager)
+                // elide inline types defined as "{ type: X }" to TypeImpl;
+                // this avoids creating a nested, redundant validation structure
+                ion.size() == 1 && ion["type"] != null -> TypeImpl(ion, schema, referenceManager)
+                else -> TypeInline(ion, schema, referenceManager)
             }
-
-            type ?: throw InvalidSchemaException("Unable to resolve type reference '$ion'")
 
             val theType = handleNullable(ion, schema, type)
             return { theType }
         }
 
-        private fun handleSymbol(ion: IonSymbol, schema: SchemaInternal): () -> TypeInternal {
-            val t = schema.getType(ion.stringValue())
+        private fun handleInlineImport(ion: IonStruct, thisSchema: SchemaInternal, referenceManager: DeferredReferenceManager): () -> TypeInternal {
+            val schemaSystem = thisSchema.getSchemaSystem()
+            val schemaId: String = ion.getIslRequiredField<IonText>("id").stringValue()
+            val typeId: IonSymbol = ion.getIslRequiredField("type")
+
+            if (thisSchema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {
+                ion.islRequireOnlyExpectedFieldNames(IonSchema_2_0.INLINE_IMPORT_KEYWORDS)
+                val thisSchemaId = thisSchema.schemaId
+                islRequire(schemaId != thisSchemaId) { "A schema may not directly import itself: $ion" }
+            }
+
+            return if (schemaSystem.doesSchemaDeclareType(schemaId, typeId)) {
+                val deferredType = referenceManager.createDeferredImportReference(schemaId, typeId);
+                { handleNullable(ion, thisSchema, deferredType) }
+            } else if (schemaSystem.getParam(IonSchemaSystemImpl.Param.ALLOW_TRANSITIVE_IMPORTS)) {
+                // Even though the type is not declared in the given schema, it could still be a transitive import if
+                // those are enabled. There is no support for circular dependency chains that include transitive imports,
+                // so we'll try to load the actual type without concern for whether it is properly deferred.
+                val importedSchema = runCatching { schemaSystem.loadSchema(schemaId) }
+                    .getOrElse { e -> throw InvalidSchemaException("Unable to load schema '$schemaId'; ${e.message}") }
+                val type = islRequireNotNull(importedSchema.getType(typeId.stringValue())) { "No such type $typeId in schema $schemaId" };
+                { type }
+            } else {
+                throw InvalidSchemaException("No type named '$typeId' found in $schemaId")
+            }
+        }
+
+        private fun handleSymbol(ion: IonSymbol, schema: SchemaInternal, referenceManager: DeferredReferenceManager): () -> TypeInternal {
+            val t = schema.getInScopeType(ion.stringValue())
+
             return if (t != null) {
                 val type = t as? TypeBuiltin ?: TypeNamed(ion, t)
                 val theType = handleNullable(ion, schema, type);
                 { theType }
             } else {
                 // type can't be resolved yet;  ask the schema to try again later
-                val deferredType = TypeReferenceDeferred(ion, schema)
-                schema.addDeferredType(deferredType);
-                { deferredType.resolve() }
+                val deferredType = referenceManager.createDeferredLocalReference(schema, ion);
+                { deferredType }
             }
         }
 
@@ -130,31 +144,4 @@ internal class TypeReference private constructor() {
             }
         }
     }
-}
-
-/**
- * Represents a type reference that can't be resolved yet.
- */
-internal class TypeReferenceDeferred(
-    nameSymbol: IonSymbol,
-    private val schema: SchemaInternal
-) : TypeInternal {
-
-    private var type: TypeInternal? = null
-    override val name: String = nameSymbol.stringValue()
-    override val schemaId: String? = schema.schemaId
-    override val isl = nameSymbol.markReadOnly()
-
-    fun attemptToResolve(): Boolean {
-        type = schema.getType(name)
-        return type != null
-    }
-
-    fun resolve(): TypeInternal = type!!
-
-    override fun getBaseType(): TypeBuiltin = throw UnsupportedOperationException()
-
-    override fun isValidForBaseType(value: IonValue): Boolean = throw UnsupportedOperationException()
-
-    override fun validate(value: IonValue, issues: Violations) = throw UnsupportedOperationException()
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
@@ -22,6 +22,7 @@ import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.CommonViolations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeInternal
 import com.amazon.ionschema.internal.TypeReference
@@ -37,6 +38,7 @@ import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 internal class Annotations_2_0 constructor(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
     private val type: () -> TypeInternal
@@ -76,9 +78,9 @@ internal class Annotations_2_0 constructor(
                 }
             }
 
-            TypeReference.create(annotationListTypeIon, schema)
+            TypeReference.create(annotationListTypeIon, schema, referenceManager)
         } else {
-            TypeReference.create(ion, schema, isField = true)
+            TypeReference.create(ion, schema, referenceManager, isField = true)
         }
     }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Element.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Element.kt
@@ -21,6 +21,7 @@ import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 import com.amazon.ionschema.internal.TypeReference.Companion.DEFAULT_ALLOWED_ANNOTATIONS
@@ -35,9 +36,10 @@ import com.amazon.ionschema.internal.util.islRequire
 internal class Element(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
-    private val typeReference = TypeReference.create(ion, schema, isField = true, allowedAnnotations = DEFAULT_ALLOWED_ANNOTATIONS + "distinct")
+    private val typeReference = TypeReference.create(ion, schema, referenceManager, isField = true, allowedAnnotations = DEFAULT_ALLOWED_ANNOTATIONS + "distinct")
     private val requireDistinctValues: Boolean
 
     init {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
@@ -20,6 +20,7 @@ import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 
@@ -29,9 +30,9 @@ import com.amazon.ionschema.internal.TypeReference
  *
  * @see https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#field_names
  */
-internal class FieldNames(ion: IonValue, schema: SchemaInternal) : ConstraintBase(ion) {
+internal class FieldNames(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager) : ConstraintBase(ion) {
 
-    private val fieldNameType = TypeReference.create(ion.clone(), schema, isField = true, allowedAnnotations = setOf("distinct"))
+    private val fieldNameType = TypeReference.create(ion.clone(), schema, referenceManager, isField = true, allowedAnnotations = setOf("distinct"))
     private val requireDistinctValues: Boolean = ion.hasTypeAnnotation("distinct")
 
     override fun validate(value: IonValue, issues: Violations) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
@@ -23,6 +23,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.Constraint
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.constraint.Occurs.Companion.OPTIONAL
 import com.amazon.ionschema.internal.util.islRequire
@@ -40,6 +41,7 @@ import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 internal class Fields(
     ionValue: IonValue,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ionValue), Constraint {
 
     private val ionStruct: IonStruct
@@ -63,7 +65,7 @@ internal class Fields(
         // Forces the field definitions to be validated
         fieldConstraints = ionStruct.associateBy(
             { it.fieldName },
-            { Occurs(it, schema, OPTIONAL, isField = true) }
+            { Occurs(it, schema, referenceManager, OPTIONAL, isField = true) }
         )
 
         if (schema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Occurs.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Occurs.kt
@@ -24,6 +24,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.Constraint
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeInternal
 import com.amazon.ionschema.internal.TypeReference
@@ -46,6 +47,7 @@ import com.amazon.ionschema.internal.util.RangeType
 internal class Occurs(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
     defaultRange: Range<Int>,
     isField: Boolean = false
 ) {
@@ -108,7 +110,7 @@ internal class Occurs(
         } else {
             ion
         }
-        typeReference = TypeReference.create(tmpIon, schema, isField, variablyOccurring = true)
+        typeReference = TypeReference.create(tmpIon, schema, referenceManager, isField, variablyOccurring = true)
 
         occursIon =
             if (occurs != null) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
@@ -23,6 +23,7 @@ import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 import com.amazon.ionschema.internal.util.IntRange
@@ -39,6 +40,7 @@ import com.amazon.ionschema.internal.util.schemaTypeName
 internal class OrderedElements(
     ion: IonValue,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
     private val nfa: NFA<IonValue, Violation> = run {
@@ -50,7 +52,7 @@ internal class OrderedElements(
         val stateBuilder = OrderedElementsNfaStatesBuilder()
         ion.forEachIndexed { idx, it ->
             val occursRange = IntRange.toIntRange((it as? IonStruct)?.get("occurs")) ?: IntRange.REQUIRED
-            val typeRef = TypeReference.create(it, schema, variablyOccurring = true)
+            val typeRef = TypeReference.create(it, schema, referenceManager, variablyOccurring = true)
             stateBuilder.addState(
                 min = occursRange.lower,
                 max = occursRange.upper,

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Type.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Type.kt
@@ -17,6 +17,7 @@ package com.amazon.ionschema.internal.constraint
 
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 
@@ -28,9 +29,10 @@ import com.amazon.ionschema.internal.TypeReference
 internal class Type(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
-    private val typeReference = TypeReference.create(ion, schema)
+    private val typeReference = TypeReference.create(ion, schema, referenceManager)
 
     override fun validate(value: IonValue, issues: Violations) = typeReference().validate(value, issues)
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaSystemTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaSystemTest.kt
@@ -43,9 +43,19 @@ class IonSchemaSystemTest {
     private val iss = IonSchemaSystemBuilder.standard().build()
 
     @Test
-    fun unresolvableSchema() {
+    fun `loadSchema(id) should throw an exception when no schema is found for that id`() {
         assertThrows<IonSchemaException> {
             iss.loadSchema("")
+        }
+    }
+
+    @Test
+    fun `loadSchema(id) should wrap exception when authorities throw exception and no schema is found`() {
+        assertThrows<IonSchemaException> {
+            IonSchemaSystemBuilder.standard()
+                .addAuthority(exceptionalAuthority) // always throws BadAuthorityException
+                .build()
+                .loadSchema("no such schema id")
         }
     }
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -38,7 +38,11 @@ class IonSchemaTests_1_0_transitive : TestFactory by IonSchemaTestsRunner(
     islVersion = v1_0,
     systemBuilder = IonSchemaSystemBuilder.standard().allowTransitiveImports(true),
     // Skip the tests for transitive imports since we're explicitly enabling the buggy behavior.
-    additionalFileFilter = { !it.path.contains("invalid_transitive_import") }
+    // Skip the tests for import cycles, since fixing cycles with transitive imports enabled is a non-goal.
+    additionalFileFilter = {
+        !it.path.contains("invalid_transitive_import") &&
+            !it.path.contains("import/cycles")
+    }
 )
 
 class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(v2_0)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -41,13 +41,7 @@ class IonSchemaTests_1_0_transitive : TestFactory by IonSchemaTestsRunner(
     additionalFileFilter = { !it.path.contains("invalid_transitive_import") }
 )
 
-class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
-    islVersion = v2_0,
-    additionalFileFilter = {
-        // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/209
-        !it.path.contains("cycles/")
-    }
-)
+class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(v2_0)
 
 /**
  * Primary test runner for the file-based test suite.

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaVersionTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaVersionTest.kt
@@ -2,8 +2,12 @@ package com.amazon.ionschema
 
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class IonSchemaVersionTest {
 
@@ -25,5 +29,34 @@ class IonSchemaVersionTest {
     fun `fromIonSymbolOrNull should return null for any other symbol`() {
         val islVersionSymbol = ION.newSymbol("\$ion_schema_0_1")
         assertNull(IonSchemaVersion.fromIonSymbolOrNull(islVersionSymbol))
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "\$ion_schema_1_0",
+            "\$ion_schema_2_0",
+            "\$ion_schema_0_1",
+            "\$ion_schema_0_1_2_3",
+            "\$ion_schema_0_abc",
+            "\$ion_schema_0",
+        ]
+    )
+    fun `isVersionMarker() should recognize symbols that are reserved for version markers`(ion: String) {
+        assertTrue(IonSchemaVersion.isVersionMarker(ION.singleValue(ion)))
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "\$ion_schema_a",
+            "\$ion_schema",
+            "\"\$ion_schema_1_0\"",
+            "null.symbol",
+            "\$ion_schema_1_0::null.symbol"
+        ]
+    )
+    fun `isVersionMarker() should reject values that are not reserved for version markers`(ion: String) {
+        assertFalse(IonSchemaVersion.isVersionMarker(ION.singleValue(ion)))
     }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
@@ -266,4 +266,12 @@ class SchemaTest {
         assertTrue(schemaCore.isl.isReadOnly)
         assertNull(schemaCore.isl.container)
     }
+
+    @Test
+    fun `when there is an unresolvable cyclic import, SchemaImpl_1_0 should throw IonSchemaException`() {
+        // I.e. it should not throw a IonSchemaException instead of a StackOverflowError
+        assertThrows<IonSchemaException> {
+            iss.loadSchema("schema/import/cycles/header_import_a.isl")
+        }
+    }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceManagerTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceManagerTest.kt
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DeferredReferenceManagerTest {
+
+    private val loadSchema: (DeferredReferenceManager, String) -> SchemaInternal = mockk(name = "loadSchema")
+    private val unloadSchema: (String) -> Unit = mockk(name = "unloadSchema")
+    private val isSchemaAlreadyLoaded: (String) -> Boolean = mockk(name = "isSchemaAlreadyLoaded")
+
+    private val typeId = mockk<IonSymbol> { every { stringValue() } returns "typeId" }
+    private val schemaId = "schemaId"
+
+    private fun mockSchema(containedType: TypeInternal?) = mockk<SchemaInternal> {
+        every { this@mockk.schemaId } returns this@DeferredReferenceManagerTest.schemaId
+        every { getType("typeId") } returns containedType
+    }
+
+    @AfterEach
+    fun cleanup() = clearMocks(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+
+    @Test
+    fun `create and resolve an ImportedTypeReferenceDeferred`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        val loadedSchema = mockSchema(containedType = mockk())
+
+        drm.createDeferredImportReference(schemaId, typeId)
+
+        every { loadSchema(drm, schemaId) } returns loadedSchema
+
+        drm.resolve()
+
+        verify { loadSchema(drm, schemaId) }
+        verify { loadedSchema.getType("typeId") }
+    }
+
+    @Test
+    fun `create and resolve an LocalTypeReferenceDeferred`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        val loadedSchema = mockSchema(containedType = mockk())
+
+        drm.createDeferredLocalReference(loadedSchema, typeId)
+        drm.resolve()
+
+        verify { loadedSchema.getType("typeId") }
+    }
+
+    @Test
+    fun `registerDependentSchema() should do nothing with a schemaId that is already loaded`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        every { isSchemaAlreadyLoaded("foo") } returns true
+
+        drm.registerDependentSchema("foo")
+
+        verify(exactly = 1) { isSchemaAlreadyLoaded("foo") }
+    }
+
+    @Test
+    fun `registerDependentSchema() should save a schemaId that is not already loaded`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        every { isSchemaAlreadyLoaded("foo") } returns false
+        every { loadSchema(drm, "foo") } returns mockk()
+
+        drm.registerDependentSchema("foo")
+        drm.resolve()
+
+        verify(exactly = 1) { isSchemaAlreadyLoaded("foo") }
+    }
+
+    @Test
+    fun `when any reference cannot be resolved, it should throw InvalidSchemaException on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        val mockSchema = mockSchema(containedType = null)
+
+        drm.createDeferredLocalReference(mockSchema, typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+    }
+
+    @Test
+    fun `when the target schema of an imported reference cannot be loaded, it should throw InvalidSchemaException on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+
+        every { loadSchema(drm, "schemaId") } throws InvalidSchemaException("Oh no!")
+
+        drm.createDeferredImportReference("schemaId", typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+    }
+
+    @Test
+    fun `when any reference is unresolvable, it should invalidate all dependent schemas on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        val mockSchema = mockSchema(containedType = null)
+
+        every { isSchemaAlreadyLoaded(any()) } returns false
+        every { unloadSchema(any()) } returns Unit
+
+        drm.registerDependentSchema("foo")
+        drm.registerDependentSchema("bar")
+        drm.createDeferredLocalReference(mockSchema, typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+
+        verify(exactly = 1) { unloadSchema("bar") }
+        verify(exactly = 1) { unloadSchema("foo") }
+    }
+
+    @Test
+    fun `when already closed, calling createDeferredLocalReference() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.createDeferredLocalReference(mockk(), mockk()) }
+    }
+
+    @Test
+    fun `when already closed, calling createDeferredImportReference() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.createDeferredImportReference("schemaId", mockk()) }
+    }
+
+    @Test
+    fun `when already closed, calling registerDependentSchema() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.registerDependentSchema("schemaId") }
+    }
+
+    @Test
+    fun `when already closed, calling resolve() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.resolve() }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceTest.kt
@@ -1,0 +1,132 @@
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+class DeferredReferenceTest {
+
+    val typeId = "typeId"
+    val typeIdSymbol = IonSystemBuilder.standard().build().newSymbol(typeId)
+
+    @Nested
+    inner class DeferredLocalReferenceTest {
+
+        @Test
+        fun resolve() {
+            val typeMock = mockk<TypeInternal>()
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns typeMock
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertEquals(typeMock, type.resolve())
+            assertEquals(typeMock, type.resolve())
+
+            verify(exactly = 1) { schemaMock.getType(typeId) }
+        }
+
+        @Test
+        fun typeNotFound() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns null
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertThrows<InvalidSchemaException> { type.resolve() }
+        }
+
+        @Test
+        fun isResolved() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertFalse(type.isResolved())
+            type.resolve()
+            assertTrue(type.isResolved())
+        }
+    }
+
+    @Nested
+    inner class DeferredImportReferenceTest {
+
+        @Test
+        fun resolve() {
+            val typeMock = mockk<TypeInternal>()
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns typeMock
+            }
+            val schemaProvider = mockk<() -> SchemaInternal>()
+            every { schemaProvider.invoke() } returns schemaMock
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                schemaProvider
+            )
+
+            assertEquals(typeMock, type.resolve())
+            assertEquals(typeMock, type.resolve())
+
+            verify(exactly = 1) { schemaProvider.invoke() }
+            verify(exactly = 1) { schemaMock.getType(typeId) }
+        }
+
+        @Test
+        fun typeNotFound() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns null
+            }
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                { schemaMock }
+            )
+
+            assertThrows<InvalidSchemaException> { type.resolve() }
+        }
+
+        @Test
+        fun isResolved() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+            }
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                { schemaMock }
+            )
+
+            assertFalse(type.isResolved())
+            type.resolve()
+            assertTrue(type.isResolved())
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentCacheTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentCacheTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.clearMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SchemaContentCacheTest {
+
+    private val ION = IonSystemBuilder.standard().build()
+    private val TYPE_ID_1 = ION.newSymbol("1")
+    private val TYPE_ID_2 = ION.newSymbol("2")
+
+    private fun defaultDelegateValue() = mutableMapOf("a" to schemaContentMockA)
+
+    private val loaderMock = mockk<(String) -> SchemaContent>()
+    private val schemaContentMockA = mockk<SchemaContent>()
+    private val schemaContentMockB = mockk<SchemaContent>()
+    private lateinit var delegate: MutableMap<String, SchemaContent>
+    private lateinit var scc: SchemaContentCache
+
+    @BeforeEach
+    fun setup() {
+        delegate = defaultDelegateValue()
+        scc = SchemaContentCache(loaderMock, delegate)
+        every { loaderMock.invoke("b") } returns schemaContentMockB
+        every { loaderMock.invoke("c") } throws Exception("Oh no!")
+    }
+
+    @AfterEach
+    fun cleanup() {
+        confirmVerified(loaderMock)
+        clearMocks(loaderMock, schemaContentMockA, schemaContentMockB)
+    }
+
+    @Test
+    fun `invalidate() should remove any corresponding entry from the backing map`() {
+        scc.invalidate("a")
+
+        assertEquals(emptyMap<String, SchemaContent>(), delegate, "The SchemaContent should have been removed")
+    }
+
+    @Test
+    fun `invalidate() should do nothing if nothing is cached for that schemaId`() {
+        scc.invalidate("b")
+
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `getSchemaContent() should return an already-cached SchemaContent`() {
+        val result = scc.getSchemaContent("a")
+
+        assertEquals(schemaContentMockA, result, "The SchemaContentCache should return the expected SchemaContent")
+    }
+
+    @Test
+    fun `getSchemaContent() should fetch and cache a not-yet cached SchemaContent`() {
+        val result = scc.getSchemaContent("b")
+
+        assertEquals(schemaContentMockB, result, "The SchemaContentCache should return the expected SchemaContent")
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `getSchemaContent() should wrap and rethrow any exceptions`() {
+        assertThrows<InvalidSchemaException> {
+            scc.getSchemaContent("c")
+        }
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+
+    @Test
+    fun `doesSchemaExist() should check the backing map before attempting to load and return true if successful`() {
+        val doesSchemaExist = scc.doesSchemaExist("a")
+
+        assertTrue(doesSchemaExist)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `doesSchemaExist() should attempt to load SchemaContent and return true if successful`() {
+        val doesSchemaExist = scc.doesSchemaExist("b")
+
+        assertTrue(doesSchemaExist)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaExist() should attempt to load SchemaContent and return false if an exception is thrown`() {
+        val doesSchemaExist = scc.doesSchemaExist("c")
+
+        assertFalse(doesSchemaExist)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return true if type is declared`() {
+        every { schemaContentMockA.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("a", TYPE_ID_1)
+
+        assertTrue(doesSchemaDeclareType)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should load SchemaContent if not in backing map`() {
+        every { schemaContentMockB.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("b", TYPE_ID_1)
+
+        assertTrue(doesSchemaDeclareType)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return false if type is not declared`() {
+        every { schemaContentMockB.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("b", TYPE_ID_2)
+
+        assertFalse(doesSchemaDeclareType)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return false if an exception is thrown`() {
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("c", TYPE_ID_1)
+
+        assertFalse(doesSchemaDeclareType)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.IonSchemaVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SchemaContentTest {
+
+    val ION = IonSystemBuilder.standard().build()
+
+    @Test
+    fun `SchemaContent determines the correct version for $ion_schema_1_0`() {
+        val ion = ION.loader.load("\$ion_schema_1_0")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v1_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent determines the correct version for $ion_schema_2_0`() {
+        val ion = ION.loader.load("\$ion_schema_2_0")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v2_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent determines the correct version when no version marker`() {
+        val ion = ION.loader.load("foo bar baz")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v1_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent lists the declared types (regardless of syntactic validity)`() {
+        val expectedTypes = listOf("foo", "bar", "baz")
+
+        val schemaContent = SchemaContent(
+            expectedTypes.map {
+                ION.singleValue("type::{ name: $it, content:(not-closed), occurs: range::['π', max] }")
+            }
+        )
+
+        assertEquals(expectedTypes, schemaContent.declaredTypes.map { it.stringValue() })
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0_Test.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0_Test.kt
@@ -1,0 +1,203 @@
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import com.amazon.ionschema.IonSchemaTests
+import com.amazon.ionschema.IonSchemaVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SchemaImpl_2_0_Test {
+
+    val ISS = IonSchemaSystemBuilder.standard()
+        .allowTransitiveImports(false)
+        .addAuthority(IonSchemaTests.authorityFor(IonSchemaVersion.v2_0))
+        .build()
+
+    fun ionStream(vararg topLevelValues: String): List<IonValue> {
+        return topLevelValues.map { ISS.ionSystem.singleValue(it) }
+    }
+
+    fun ionStruct(ion: String) = ISS.ionSystem.singleValue(ion) as IonStruct
+
+    @Test
+    fun `newType(isl) should create a new Type instance without modifying the schema`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo, type: int }")
+        val newType = schema.newType("type::{ name: bar }")
+
+        val oldSchemaTypes = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedOldSchemaTypes = setOf("foo")
+        assertEquals(expectedOldSchemaTypes, oldSchemaTypes, "The original schema should not be modified.")
+    }
+
+    @Test
+    fun `plusType(type) should return a new schema instance that contains the new type and the types from the original schema`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val newType = schema.newType("type::{ name: bar }")
+        val newSchema = schema.plusType(newType)
+
+        val oldSchemaTypes = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedOldSchemaTypes = setOf("foo")
+        assertEquals(expectedOldSchemaTypes, oldSchemaTypes, "The original schema should not be modified.")
+
+        val newSchemaTypes = newSchema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedNewSchemaTypes = setOf("foo", "bar")
+        assertEquals(expectedNewSchemaTypes, newSchemaTypes)
+    }
+
+    @Test
+    fun `plusType(type) should return a new schema instance, replacing an existing type with the same name`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val newType = schema.newType("type::{ name: foo, type: string }")
+        val newSchema = schema.plusType(newType)
+
+        val oldFooTypeIsl = schema.getType("foo")?.isl
+        val expectedOldFooTypeIsl = ionStruct("type::{ name: foo }")
+        assertEquals(expectedOldFooTypeIsl, oldFooTypeIsl, "The 'foo' type in the original schema should not be modified.")
+
+        val newFooTypeIsl = newSchema.getType("foo")?.isl
+        val expectedNewFooTypeIsl = ionStruct("type::{ name: foo, type: string }")
+        assertEquals(expectedNewFooTypeIsl, newFooTypeIsl)
+    }
+
+    @Test
+    fun `getType(name) should return a declared type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        assertNotNull(schema.getType("foo"))
+    }
+
+    @Test
+    fun `getType(name) should return a built-in type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        assertNotNull(schema.getType("text"))
+    }
+
+    @Test
+    fun `getType(name) should not return an imported type`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+        val type = schema.getType("positive_int")
+        assertNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should return a declared type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val type = schema.getDeclaredType("foo")
+        assertNotNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should not return a built-in type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val type = schema.getDeclaredType("text")
+        assertNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should not return an imported type`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+        val type = schema.getDeclaredType("positive_int")
+        assertNull(type)
+    }
+
+    @Test
+    fun `getDeclaredTypes() should return only top level types that are declared in the schema`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+
+        val result = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expected = setOf("foo", "bar", "baz")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getTypes() should return built-in types and declared types`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+
+        val result = schema.getTypes().asSequence().map { it.name }.toSet()
+
+        assertTrue(result.containsAll(setOf("foo", "bar", "baz")), "Result should contain the declared types")
+        assertFalse(result.contains("positive_int"), "Result should not contain the imported types")
+        assertTrue(result.contains("text"), "Result should contain built-in types")
+    }
+
+    @Test
+    fun `getImports() should return the imports objects`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+        // Unfortunately, [ImportImpl] doesn't have a proper definition of equality, so we're converting to a
+        // Map<String, List<String>>> which is like a multimap of schemaId to type names imported from that schema.
+        assertEquals(
+            mapOf("util.isl" to setOf("positive_int")),
+            schema.getImports().asSequence().associate { it.id to it.getTypes().asSequence().map { it.name }.toSet() },
+        )
+    }
+
+    @Test
+    fun `getImport(id) should return the imports for the given schema`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+
+        val import = schema.getImport("util.isl")
+        assertNotNull(import)
+        // Unfortunately, [ImportImpl] doesn't have a proper definition of equality, so we're just comparing the type
+        // names in the import
+        assertEquals(
+            setOf("positive_int"),
+            import?.getTypes()?.asSequence()?.map { it.name }?.toSet(),
+        )
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
@@ -30,7 +30,7 @@ class OrderedElementsTest {
     @ParameterizedTest(name = "ordered_elements:{0} should {1} {2}")
     @MethodSource("testCases")
     fun test(ionText: String, ignored: String, value: String, expectValid: Boolean) {
-        val constraint = OrderedElements(ION.singleValue(ionText), ISS.newSchema())
+        val constraint = ISS.usingReferenceManager { OrderedElements(ION.singleValue(ionText), ISS.newSchema(), it) }
         val v = Violations()
         constraint.validate(ION.singleValue(value), v, debug = true)
         assertEquals(expectValid, v.isValid())
@@ -39,7 +39,7 @@ class OrderedElementsTest {
     @ParameterizedTest(name = "violations message - {0}")
     @MethodSource("messageTestCases")
     fun test_messages(_name: String, constraintIon: String, value: String, message: String) {
-        val constraint = OrderedElements(ION.singleValue(constraintIon), ISS.newSchema())
+        val constraint = ISS.usingReferenceManager { OrderedElements(ION.singleValue(constraintIon), ISS.newSchema(), it) }
         val v = Violations()
         constraint.validate(ION.singleValue(value), v, debug = true)
         // Trim all whitespace to normalize before comparing


### PR DESCRIPTION
### Issue #, if available:

Partial fix of #209 

### Description of changes:

#### General strategy:
* The current implementation does a depth first traversal, recursively loading schemas until it either hits a leaf node, or it discovers a cycle. It also eagerly loads all imported types, and so the types in Schema A cannot be resolved until all of its imports are loaded. When there's a cycle, we end up with a chicken and egg problem. Schema A cannot load its types until its imports from Schema B are loaded, and Schema B cannot load its types until its imports from Schema A are loaded.
* New implementation
  * A schema is loaded in two phases.
  * The first phase simply loads the Ion stream into a `SchemaContent` object. This is enough for us to inspect the names of the types declared by the schema, and as a result we can be sure that a type _exist_ in a schema before the schema is fully loaded.
  * The second phase goes from `SchemaContent` to `SchemaInternal`. This is where we ensure that the schema is syntactically and semantically valid, and we construct all of the `Type` objects.
  * When a schema is undergoing the second phase of loading, it only requires its dependencies to be in the first phase of loading. However, this means that we cannot resolve any imported types right away; it must be deferred until after the imported schema had undergone the second phase of loading.
  * This is where the `DeferredReferenceManager` comes into play. It is responsible for collecting deferred type references across multiple schemas, and ensuring that all of the references are resolved. DeferredReferences point to types that are guaranteed to exist, so they are only unresolvable if the target schema/type has some invalid syntax or has its own bad imports.
  * If any DeferredReferences cannot be resolved, then _all_ schemas that were loaded using that particular `DeferredReferenceManager` instance are evicted from the `IonSchemaSystem`'s `SchemaCache` so that the `SchemaCache` isn't polluted with unresolved/invalid schemas. The same schemas are also evicted from the `SchemaContentCache` so that if they get changed on disk, they can be reloaded properly.

The new implementation intentionally ignores the problem of cycles that are created using transitive imports. It is possible that this may work for some transitive import cycles, but that was a non-goal of this PR.

#### Description of changes in this PR:

 * Adds `DeferredReferenceManager` and `SchemaContentCache`
 * Also adds the data types that these classes manage
 * Also adds unit tests

### Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:

None yet.

----

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
