### PR TITLE
Adds DeferredReferenceManager and SchemaContentCache

### DIFF
--- a/ion-schema/build.gradle
+++ b/ion-schema/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
   testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
   testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+  testImplementation 'io.mockk:mockk:1.13.3'
   testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.Violations
+
+/**
+ * The classes in this file are an implementation detail of [DeferredReferenceManager], and should not be used outside
+ * [DeferredReferenceManager] except for testing. To properly encapsulate [DeferredReference] and its implementations,
+ * we would have to make them private inside [DeferredReferenceManager], but that makes it difficult to thoroughly test
+ * these classes. In order to directly test the private classes, we would have to use reflection to modify the class
+ * visibility in the unit tests. However, this will not work if the ClassLoader has a SecurityManager that prohibits
+ * changing visibility, and so the tests would be brittle.
+ *
+ * Instead, we have a [RequiresOptIn] annotation for all classes in this file. If you try to use [DeferredReference] or
+ * any implementations without explicitly opting in, it will result in a compile-time error. Opting in requires
+ *
+ * ```
+ * @OptIn(DeferredReferenceManagerImplementationDetails::class)
+ * ```
+ *
+ * Essentially, this is like a much stricter version of the @VisibleForTesting annotation that is commonly used in Java.
+ */
+@RequiresOptIn(
+    message = "Do not use DeferredReference and its implementations outside DeferredReferenceManager or unit tests.",
+    level = RequiresOptIn.Level.ERROR
+)
+@Retention(AnnotationRetention.BINARY)
+internal annotation class DeferredReferenceManagerImplementationDetails
+
+/**
+ * Represents a named ISL type that is known to be declared in a schema document, but it is not known whether an
+ * instance of [TypeInternal] has been created for that ISL type yet.
+ *
+ * Concrete instances of [DeferredReference] should only be created by an instance of [DeferredReferenceManager]. The
+ * [DeferredReferenceManager] ensures that all [DeferredReference]s are resolved before they are used for validation.
+ *
+ * Before it is resolved, any attempt to use validation functions will throw an [IllegalStateException]. Once it is
+ * resolved, a [DeferredReference] acts like an ordinary [TypeInternal].
+ */
+@DeferredReferenceManagerImplementationDetails
+internal interface DeferredReference : TypeInternal {
+    override val isl: IonSymbol
+    override val name: String
+        get() = isl.stringValue()
+
+    /**
+     * Returns the [TypeInternal] that this [DeferredReference] resolves to.
+     * If it cannot be resolved, throws [InvalidSchemaException].
+     */
+    fun resolve(): TypeInternal
+
+    /**
+     * Returns true if this [DeferredReference] is already resolved.
+     */
+    fun isResolved(): Boolean
+
+    companion object {
+        private fun illegalMethodCallBeforeResolving(): Nothing {
+            throw IllegalStateException("This should be unreachable because this method should not be called before the call to DeferredReferenceManager.resolve() is complete.")
+        }
+    }
+    override fun getBaseType(): TypeBuiltin = if (isResolved()) resolve().getBaseType() else illegalMethodCallBeforeResolving()
+    override fun isValidForBaseType(value: IonValue): Boolean = if (isResolved()) resolve().isValidForBaseType(value) else illegalMethodCallBeforeResolving()
+    override fun validate(value: IonValue, issues: Violations) = if (isResolved()) resolve().validate(value, issues) else illegalMethodCallBeforeResolving()
+}
+
+/**
+ * An implementation of [DeferredReference] that refers to a [TypeInternal] that is declared in a [SchemaInternal]
+ * that has already been instantiated.
+ *
+ * Use this for references to other types that are in scope for the same schema that the reference is being created for.
+ */
+@DeferredReferenceManagerImplementationDetails
+internal class DeferredLocalReference(
+    override val isl: IonSymbol,
+    private val schema: SchemaInternal
+) : DeferredReference {
+    override val schemaId: String? = schema.schemaId
+    private var type: TypeInternal? = null
+
+    override fun resolve(): TypeInternal {
+        return type
+            ?: schema.getType(name)?.also { type = it }
+            ?: throw InvalidSchemaException("Unable to resolve type $isl")
+    }
+    override fun isResolved(): Boolean = type != null
+}
+
+/**
+ * An implementation of [DeferredReference] that refers to a [TypeInternal] that is declared in a [SchemaInternal]
+ * that has not necessarily been instantiated yet. This class also implements [ImportedType], which means that
+ * [schemaId] is required to be non-null.
+ *
+ * Use this for references to other types that are defined in other schemas.
+ */
+@DeferredReferenceManagerImplementationDetails
+internal class DeferredImportReference(
+    override val isl: IonSymbol,
+    override val schemaId: String,
+    private val schemaProvider: () -> SchemaInternal
+) : DeferredReference, ImportedType {
+    override val importedFromSchemaId: String
+        get() = schemaId
+
+    private var type: TypeInternal? = null
+
+    override fun resolve(): TypeInternal {
+        return type
+            ?: schemaProvider().getType(name)?.also { type = it }
+            ?: throw InvalidSchemaException("Unable to resolve type $isl")
+    }
+    override fun isResolved(): Boolean = type != null
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReferenceManager.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReferenceManager.kt
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.Schema
+import java.util.LinkedList
+import java.util.Queue
+
+/**
+ * A single-use "session" for creating, tracking, and resolving deferred references _for multiple [Schema]_.
+ *
+ * A [DeferredReferenceManager] allows you to create [DeferredReference] instances, and it keeps track of any
+ * [DeferredReference] instances that it creates. When this [DeferredReferenceManager] is closed, it attempts to
+ * resolve all of the [DeferredReference]. If any cannot be resolved, it throws an [InvalidSchemaException] listing
+ * the types that cannot be resolved.
+ *
+ * A [DeferredReferenceManager] ensures that all [DeferredReference]s it creates refer to a type that does actually
+ * exist in the source ISL. (Caveat—it can't yet do that for local references in anonymous schemas.) This check is not
+ * strictly necessary since the non-existence of the type would be discovered when attempting to resolve the type, but
+ * including this check does help to reason about the correctness of the implementation. If it is discovered to be a
+ * performance bottleneck, it could safely be removed.
+ *
+ * In addition, a schema can be registered with the [DeferredReferenceManager] as being dependent on the outcome of
+ * resolving the deferred references. See [registerDependentSchema] for details.
+ *
+ * Once a [DeferredReferenceManager] instance has been closed, you cannot use that instance to create any new references
+ * nor can you register any dependent schemas, and the instance should be discarded. Attempting to perform any operation
+ * once closed will result in an [IllegalStateException] being thrown.
+ */
+@OptIn(DeferredReferenceManagerImplementationDetails::class)
+internal class DeferredReferenceManager(
+    private val loadSchemaFn: (DeferredReferenceManager, String) -> SchemaInternal,
+    private val unloadSchema: (String) -> Unit,
+    private val isSchemaAlreadyLoaded: (String) -> Boolean,
+    private val doesSchemaDeclareType: (String, IonSymbol) -> Boolean,
+) {
+
+    private val deferredTypeReferences: Queue<DeferredReference> = LinkedList()
+    private val dependentSchemas = mutableSetOf<String>()
+    private var isClosed = false
+
+    /**
+     * Creates a [DeferredLocalReference] for a type with name [typeId] that is in scope for the given [schema].
+     */
+    fun createDeferredLocalReference(schema: SchemaInternal, typeId: IonSymbol): TypeInternal {
+        if (isClosed) throw IllegalStateException("Cannot create a new reference using a closed DeferredReferenceManager")
+        // TODO: See if it's possible to enforce this guarantee for anonymous schemas
+        schema.schemaId?.let { schemaId ->
+            if (!doesSchemaDeclareType(schemaId, typeId)) throw InvalidSchemaException("No type named '$typeId' in schema $schemaId")
+        }
+        val ref = DeferredLocalReference(typeId, schema)
+        deferredTypeReferences.add(ref)
+        return ref
+    }
+
+    /**
+     * Creates an [DeferredImportReference] for a type with name [typeId] that is declared in [schemaId].
+     */
+    fun createDeferredImportReference(schemaId: String, typeId: IonSymbol): ImportedType {
+        if (isClosed) throw IllegalStateException("Cannot create a new reference using a closed DeferredReferenceManager")
+        if (!doesSchemaDeclareType(schemaId, typeId)) throw InvalidSchemaException("No type named '$typeId' in schema $schemaId")
+        val ref = DeferredImportReference(typeId, schemaId) { loadSchemaFn(this, schemaId) }
+        deferredTypeReferences.add(ref)
+        return ref
+    }
+
+    /**
+     * Indicates that the validity of the [Schema] for the given [schemaId] depends on the outcome of this
+     * [DeferredReferenceManager]. If the [Schema] for the given [schemaId] is already loaded into the [IonSchemaSystemImpl],
+     * then this function does nothing. Otherwise, the [schemaId] is added to the list of [dependentSchemas] that will
+     * need to be invalidated if any deferred references cannot be resolved.
+     *
+     * In other words, we cannot guarantee that a schema is valid until we have validated all of its deferred references.
+     * If any references are deferred, and then later discovered to be invalid, then we must invalidate all schemas that
+     * depend on that reference—directly or indirectly. In practice, however, this class takes a safe-but-naive approach
+     * and will unload *all* schemas that are dependent on the outcome of this [DeferredReferenceManager].
+     *
+     * This function should only be called from the initializer block of a [Schema] implementation.
+     */
+    internal fun registerDependentSchema(schemaId: String) {
+        if (isClosed) throw IllegalStateException("Cannot register a dependent schema with a closed DeferredReferenceManager")
+
+        // If this function is only called from the init block of a Schema implementation (as prescribed), then it
+        // should not be possible for the given schemaId to already be loaded. However, we check anyway so that this
+        // function does not have to make assumptions about its preconditions.
+        if (isSchemaAlreadyLoaded(schemaId)) return
+
+        dependentSchemas.add(schemaId)
+    }
+
+    fun resolve() {
+        if (isClosed) throw IllegalStateException("Cannot call resolve() on a closed DeferredReferenceManager")
+        try {
+
+            // NOTE: we must use a loop rather than an iterator/stream/sequence since more items can be
+            // added to the queue as a side effect of resolving a deferred type reference.
+            while (deferredTypeReferences.isNotEmpty()) {
+                deferredTypeReferences.poll().resolve()
+            }
+        } catch (e: Exception) {
+            // If anything goes wrong, evict all possibly bad schemas that might have been cached
+            dependentSchemas.forEach { unloadSchema(it) }
+            throw e
+        } finally {
+            isClosed = true
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.getIslRequiredField
+
+/**
+ * A wrapper class for a stream of IonValue that is expected to be an Ion Schema document.
+ *
+ * The purpose of this class is similar to a C header file—so that we can know about all the declared types in a schema
+ * document before we've fully loaded the schema document into the schema system. This is essential for being able to
+ * resolve cyclical dependencies. See also [Forward Declaration](https://en.wikipedia.org/wiki/Forward_declaration).
+ *
+ * This class performs some processing in its initialization block in order to determine the Ion Schema version and
+ * the names of all the types declared by the schema document, but it does not perform any syntactic or semantic
+ * validation of the schema document.
+ */
+internal class SchemaContent(val isl: List<IonValue>) {
+    val version: IonSchemaVersion
+    val declaredTypes: List<IonSymbol>
+    init {
+        var version: IonSchemaVersion = IonSchemaVersion.v1_0
+        declaredTypes = isl
+            .onEach {
+                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                    version = IonSchemaVersion.fromIonSymbolOrNull(it)
+                        ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
+                }
+            }
+            .filterIsInstance<IonStruct>()
+            .filter { it.hasTypeAnnotation("type") }
+            .map { it.getIslRequiredField("name") }
+        this.version = version
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+
+/**
+ * A class that caches the uninterpreted content of a Schema document. This enables us to determine which types are
+ * declared in a schema prior to having a [SchemaInternal] instance for the schema, which is especially useful for
+ * checking the validity of a type reference without having to resolve the type reference to a [TypeInternal] instance.
+ */
+internal class SchemaContentCache constructor(
+    private val loader: (String) -> SchemaContent,
+    private val delegate: MutableMap<String, SchemaContent> = mutableMapOf(),
+) {
+    constructor(
+        /**
+         * A function to look up a schema that has already been loaded by the [IonSchemaSystemImpl] so that we can ensure
+         * that this [SchemaContentCache] has a consistent view of a schema, and so that it doesn't do unnecessary work to
+         * load a schema document that has already been loaded e.g. from disk.
+         */
+        getPreloadedSchemaIsl: (String) -> List<IonValue>?,
+        /**
+         * A function to load the schema document content for a schemaId (most likely by using authorities).
+         */
+        loadSchemaIslForId: (String) -> List<IonValue>
+    ) : this({ SchemaContent(getPreloadedSchemaIsl(it) ?: loadSchemaIslForId(it)) })
+
+    /**
+     * Returns the [SchemaContent] for the given [schemaId]. Throws an [InvalidSchemaException] if the schema is not
+     * found or is malformed Ion.
+     */
+    fun getSchemaContent(schemaId: String): SchemaContent {
+        return delegate.getOrPut(schemaId) {
+            try {
+                loader(schemaId)
+            } catch (e: Exception) {
+                throw InvalidSchemaException("Unable to load schema $schemaId: ${e.message}")
+            }
+        }
+    }
+
+    /**
+     * Checks if a schema exists for the given schema ID. Does not guarantee that the schema is valid ISL—just that
+     * there is some Ion that can be found using this schema ID.
+     *
+     * Has the side effect of loading the content for the given [schemaId] if that content has not already been loaded
+     * into this instance of [SchemaContentCache].
+     */
+    fun doesSchemaExist(schemaId: String): Boolean {
+        return runCatching { getSchemaContent(schemaId) }.isSuccess
+    }
+
+    /**
+     * Checks if the schema document for the given [schemaId] has a named type definition with the name [typeId]. This
+     * does not guarantee that the type definition or the schema document are valid—only that a `type::{ name: ... }`
+     * exists in the schema document for the given [typeId].
+     *
+     * Has the side effect of loading the content for the given [schemaId] if that content has not already been loaded
+     * into this instance of [SchemaContentCache].
+     */
+    fun doesSchemaDeclareType(schemaId: String, typeId: IonSymbol): Boolean {
+        return runCatching { typeId in getSchemaContent(schemaId).declaredTypes }.getOrElse { false }
+    }
+
+    /**
+     * Removes a schema from this cache.
+     */
+    fun invalidate(schemaId: String) {
+        delegate.remove(schemaId)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceManagerTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceManagerTest.kt
@@ -1,0 +1,190 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+internal class DeferredReferenceManagerTest {
+
+    private val loadSchema: (DeferredReferenceManager, String) -> SchemaInternal = mockk(name = "loadSchema")
+    private val unloadSchema: (String) -> Unit = mockk(name = "unloadSchema")
+    private val isSchemaAlreadyLoaded: (String) -> Boolean = mockk(name = "isSchemaAlreadyLoaded")
+    private val doesSchemaDeclareType: (String, IonSymbol) -> Boolean = mockk(name = "doesSchemaDeclareType") {
+        every { this@mockk(any(), any()) } returns true
+    }
+
+    private val typeId = mockk<IonSymbol> { every { stringValue() } returns "typeId" }
+    private val schemaId = "schemaId"
+
+    private fun mockSchema(containedType: TypeInternal?) = mockk<SchemaInternal> {
+        every { this@mockk.schemaId } returns this@DeferredReferenceManagerTest.schemaId
+        every { getType("typeId") } returns containedType
+    }
+
+    @AfterEach
+    fun cleanup() = clearMocks(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+
+    @Test
+    fun `create and resolve an DeferredImportReference`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        val loadedSchema = mockSchema(containedType = mockk())
+        every { loadSchema(drm, schemaId) } returns loadedSchema
+
+        drm.createDeferredImportReference(schemaId, typeId)
+
+        // This should not be called until we call drm.resolve()
+        verify(exactly = 0) { loadSchema(drm, schemaId) }
+
+        drm.resolve()
+
+        verify { doesSchemaDeclareType(schemaId, typeId) }
+        verify { loadSchema(drm, schemaId) }
+        verify { loadedSchema.getType("typeId") }
+    }
+
+    @Test
+    fun `attempting to create an DeferredImportReference for a type that is not declared should throw InvalidSchemaException`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        clearMocks(doesSchemaDeclareType)
+        every { doesSchemaDeclareType(schemaId, typeId) } returns false
+
+        assertThrows<InvalidSchemaException> {
+            drm.createDeferredImportReference(schemaId, typeId)
+        }
+
+        verify { doesSchemaDeclareType(schemaId, typeId) }
+    }
+
+    @Test
+    fun `create and resolve an DeferredLocalReference`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        val loadedSchema = mockSchema(containedType = mockk())
+
+        drm.createDeferredLocalReference(loadedSchema, typeId)
+        drm.resolve()
+
+        verify { loadedSchema.getType("typeId") }
+    }
+
+    @Test
+    fun `attempting to create an DeferredLocalReference for a type that is not declared should throw InvalidSchemaException`() {
+        // Caveat—this does not apply to anonymous schemas for now.
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        val loadedSchema = mockSchema(containedType = mockk())
+        clearMocks(doesSchemaDeclareType)
+        every { doesSchemaDeclareType(schemaId, typeId) } returns false
+
+        assertThrows<InvalidSchemaException> {
+            drm.createDeferredLocalReference(loadedSchema, typeId)
+        }
+
+        verify { doesSchemaDeclareType(schemaId, typeId) }
+    }
+
+    @Test
+    fun `registerDependentSchema() should do nothing with a schemaId that is already loaded`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        every { isSchemaAlreadyLoaded("foo") } returns true
+
+        drm.registerDependentSchema("foo")
+
+        verify(exactly = 1) { isSchemaAlreadyLoaded("foo") }
+    }
+
+    @Test
+    fun `registerDependentSchema() should save a schemaId that is not already loaded`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        every { isSchemaAlreadyLoaded("foo") } returns false
+        every { loadSchema(drm, "foo") } returns mockk()
+
+        drm.registerDependentSchema("foo")
+        drm.resolve()
+
+        verify(exactly = 1) { isSchemaAlreadyLoaded("foo") }
+    }
+
+    @Test
+    fun `when any reference cannot be resolved, it should throw InvalidSchemaException on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        val mockSchema = mockSchema(containedType = null)
+
+        drm.createDeferredLocalReference(mockSchema, typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+    }
+
+    @Test
+    fun `when the target schema of an imported reference cannot be loaded, it should throw InvalidSchemaException on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+
+        every { loadSchema(drm, "schemaId") } throws InvalidSchemaException("Oh no!")
+
+        drm.createDeferredImportReference("schemaId", typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+    }
+
+    @Test
+    fun `when any reference is unresolvable, it should invalidate all dependent schemas on close`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        val mockSchema = mockSchema(containedType = null)
+
+        every { isSchemaAlreadyLoaded(any()) } returns false
+        every { unloadSchema(any()) } returns Unit
+
+        drm.registerDependentSchema("foo")
+        drm.registerDependentSchema("bar")
+        drm.createDeferredLocalReference(mockSchema, typeId)
+        assertThrows<InvalidSchemaException> { drm.resolve() }
+
+        verify(exactly = 1) { unloadSchema("bar") }
+        verify(exactly = 1) { unloadSchema("foo") }
+    }
+
+    @Test
+    fun `when already closed, calling createDeferredLocalReference() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.createDeferredLocalReference(mockk(), mockk()) }
+    }
+
+    @Test
+    fun `when already closed, calling createDeferredImportReference() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.createDeferredImportReference("schemaId", mockk()) }
+    }
+
+    @Test
+    fun `when already closed, calling registerDependentSchema() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.registerDependentSchema("schemaId") }
+    }
+
+    @Test
+    fun `when already closed, calling resolve() should throw an exception`() {
+        val drm = DeferredReferenceManager(loadSchema, unloadSchema, isSchemaAlreadyLoaded, doesSchemaDeclareType)
+        drm.resolve()
+        assertThrows<IllegalStateException> { drm.resolve() }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/DeferredReferenceTest.kt
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+// Opting in to DeferredReferenceManagerImplementationDetails is okay here because we're testing the DeferredReferences.
+@OptIn(DeferredReferenceManagerImplementationDetails::class)
+class DeferredReferenceTest {
+
+    val typeId = "typeId"
+    val typeIdSymbol = IonSystemBuilder.standard().build().newSymbol(typeId)
+
+    @Nested
+    inner class DeferredLocalReferenceTest {
+
+        @Test
+        fun resolve() {
+            val typeMock = mockk<TypeInternal>()
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns typeMock
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertEquals(typeMock, type.resolve())
+            assertEquals(typeMock, type.resolve())
+
+            verify(exactly = 1) { schemaMock.getType(typeId) }
+        }
+
+        @Test
+        fun isResolved() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertFalse(type.isResolved())
+            type.resolve()
+            assertTrue(type.isResolved())
+        }
+
+        @Test
+        fun `when resolving the type fails, should throw InvalidSchemaException`() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns null
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertThrows<InvalidSchemaException> { type.resolve() }
+        }
+
+        @Test
+        fun `using validation functions before resolving should throw IllegalStateException`() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+                every { schemaId } returns "schemaId"
+            }
+
+            val type = DeferredLocalReference(
+                typeIdSymbol,
+                schemaMock
+            )
+
+            assertThrows<IllegalStateException> { type.isValidForBaseType(mockk()) }
+            assertThrows<IllegalStateException> { type.getBaseType() }
+            assertThrows<IllegalStateException> { type.validate(mockk(), mockk()) }
+        }
+    }
+
+    @Nested
+    inner class DeferredImportReferenceTest {
+
+        @Test
+        fun resolve() {
+            val typeMock = mockk<TypeInternal>()
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns typeMock
+            }
+            val schemaProvider = mockk<() -> SchemaInternal>()
+            every { schemaProvider.invoke() } returns schemaMock
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                schemaProvider
+            )
+
+            assertEquals(typeMock, type.resolve())
+            assertEquals(typeMock, type.resolve())
+
+            verify(exactly = 1) { schemaProvider.invoke() }
+            verify(exactly = 1) { schemaMock.getType(typeId) }
+        }
+
+        @Test
+        fun isResolved() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+            }
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                { schemaMock }
+            )
+
+            assertFalse(type.isResolved())
+            type.resolve()
+            assertTrue(type.isResolved())
+        }
+
+        @Test
+        fun `when resolving the type fails, should throw InvalidSchemaException`() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns null
+            }
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                { schemaMock }
+            )
+
+            assertThrows<InvalidSchemaException> { type.resolve() }
+        }
+
+        @Test
+        fun `using validation functions before resolving should throw IllegalStateException`() {
+            val schemaMock = mockk<SchemaInternal> {
+                every { getType(typeId) } returns mockk<TypeInternal>()
+            }
+
+            val type = DeferredImportReference(
+                typeIdSymbol,
+                "schemaId",
+                { schemaMock }
+            )
+
+            assertThrows<IllegalStateException> { type.isValidForBaseType(mockk()) }
+            assertThrows<IllegalStateException> { type.getBaseType() }
+            assertThrows<IllegalStateException> { type.validate(mockk(), mockk()) }
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentCacheTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentCacheTest.kt
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import io.mockk.clearMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class SchemaContentCacheTest {
+
+    private val ION = IonSystemBuilder.standard().build()
+    private val TYPE_ID_1 = ION.newSymbol("1")
+    private val TYPE_ID_2 = ION.newSymbol("2")
+
+    private fun defaultDelegateValue() = mutableMapOf("a" to schemaContentMockA)
+
+    private val loaderMock = mockk<(String) -> SchemaContent>()
+    private val schemaContentMockA = mockk<SchemaContent>()
+    private val schemaContentMockB = mockk<SchemaContent>()
+    private lateinit var delegate: MutableMap<String, SchemaContent>
+    private lateinit var scc: SchemaContentCache
+
+    @BeforeEach
+    fun setup() {
+        delegate = defaultDelegateValue()
+        scc = SchemaContentCache(loaderMock, delegate)
+        every { loaderMock.invoke("b") } returns schemaContentMockB
+        every { loaderMock.invoke("c") } throws Exception("Oh no!")
+    }
+
+    @AfterEach
+    fun cleanup() {
+        confirmVerified(loaderMock)
+        clearMocks(loaderMock, schemaContentMockA, schemaContentMockB)
+    }
+
+    @Test
+    fun `invalidate() should remove any corresponding entry from the backing map`() {
+        scc.invalidate("a")
+
+        assertEquals(emptyMap<String, SchemaContent>(), delegate, "The SchemaContent should have been removed")
+    }
+
+    @Test
+    fun `invalidate() should do nothing if nothing is cached for that schemaId`() {
+        scc.invalidate("b")
+
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `getSchemaContent() should return an already-cached SchemaContent`() {
+        val result = scc.getSchemaContent("a")
+
+        assertEquals(schemaContentMockA, result, "The SchemaContentCache should return the expected SchemaContent")
+    }
+
+    @Test
+    fun `getSchemaContent() should fetch and cache a not-yet cached SchemaContent`() {
+        val result = scc.getSchemaContent("b")
+
+        assertEquals(schemaContentMockB, result, "The SchemaContentCache should return the expected SchemaContent")
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `getSchemaContent() should wrap and rethrow any exceptions`() {
+        assertThrows<InvalidSchemaException> {
+            scc.getSchemaContent("c")
+        }
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+
+    @Test
+    fun `doesSchemaExist() should check the backing map before attempting to load and return true if successful`() {
+        val doesSchemaExist = scc.doesSchemaExist("a")
+
+        assertTrue(doesSchemaExist)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `doesSchemaExist() should attempt to load SchemaContent and return true if successful`() {
+        val doesSchemaExist = scc.doesSchemaExist("b")
+
+        assertTrue(doesSchemaExist)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaExist() should attempt to load SchemaContent and return false if an exception is thrown`() {
+        val doesSchemaExist = scc.doesSchemaExist("c")
+
+        assertFalse(doesSchemaExist)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return true if type is declared`() {
+        every { schemaContentMockA.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("a", TYPE_ID_1)
+
+        assertTrue(doesSchemaDeclareType)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should load SchemaContent if not in backing map`() {
+        every { schemaContentMockB.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("b", TYPE_ID_1)
+
+        assertTrue(doesSchemaDeclareType)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return false if type is not declared`() {
+        every { schemaContentMockB.declaredTypes } returns listOf(TYPE_ID_1)
+
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("b", TYPE_ID_2)
+
+        assertFalse(doesSchemaDeclareType)
+        assertEquals(mapOf("a" to schemaContentMockA, "b" to schemaContentMockB), delegate, "The fetched SchemaContent should be cached")
+        verify(exactly = 1) { loaderMock.invoke("b") }
+    }
+
+    @Test
+    fun `doesSchemaDeclareType() should return false if an exception is thrown`() {
+        val doesSchemaDeclareType = scc.doesSchemaDeclareType("c", TYPE_ID_1)
+
+        assertFalse(doesSchemaDeclareType)
+        assertEquals(defaultDelegateValue(), delegate, "The backing map should be unchanged")
+        verify(exactly = 1) { loaderMock.invoke("c") }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaContentTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.IonSchemaVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SchemaContentTest {
+
+    val ION = IonSystemBuilder.standard().build()
+
+    @Test
+    fun `SchemaContent determines the correct version for $ion_schema_1_0`() {
+        val ion = ION.loader.load("\$ion_schema_1_0")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v1_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent determines the correct version for $ion_schema_2_0`() {
+        val ion = ION.loader.load("\$ion_schema_2_0")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v2_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent determines the correct version when no version marker`() {
+        val ion = ION.loader.load("foo bar baz")
+        val schemaContent = SchemaContent(ion)
+        assertEquals(IonSchemaVersion.v1_0, schemaContent.version)
+    }
+
+    @Test
+    fun `SchemaContent lists the declared types (regardless of syntactic validity)`() {
+        val expectedTypes = listOf("foo", "bar", "baz")
+
+        val schemaContent = SchemaContent(
+            expectedTypes.map {
+                ION.singleValue("type::{ name: $it, content:(not-closed), occurs: range::['π', max] }")
+            }
+        )
+
+        assertEquals(expectedTypes, schemaContent.declaredTypes.map { it.stringValue() })
+    }
+}


### PR DESCRIPTION
### Issue #, if available:

Partial progress for fixing #209 

### Description of changes:

#### General strategy:
* The current implementation does a depth first traversal, recursively loading schemas until it either hits a leaf node, or it discovers a cycle. It also eagerly loads all imported types, and so the types in Schema A cannot be resolved until all of its imports are loaded. When there's a cycle, we end up with a chicken and egg problem. Schema A cannot load its types until its imports from Schema B are loaded, and Schema B cannot load its types until its imports from Schema A are loaded.
* New implementation
  * A schema is loaded in two phases.
  * The first phase simply loads the Ion stream into a `SchemaContent` object. This is enough for us to inspect the names of the types declared by the schema, and as a result we can be sure that a type _exist_ in a schema before the schema is fully loaded.
  * The second phase goes from `SchemaContent` to `SchemaInternal`. This is where we ensure that the schema is syntactically and semantically valid, and we construct all of the `Type` objects.
  * When a schema is undergoing the second phase of loading, it only requires its dependencies to be in the first phase of loading. However, this means that we cannot resolve any imported types right away; it must be deferred until after the imported schema had undergone the second phase of loading.
  * This is where the `DeferredReferenceManager` comes into play. It is responsible for collecting deferred type references across multiple schemas, and ensuring that all of the references are resolved. DeferredReferences point to types that are guaranteed to exist, so they are only unresolvable if the target schema/type has some invalid syntax or has its own bad imports.
  * If any DeferredReferences cannot be resolved, then _all_ schemas that were loaded using that particular `DeferredReferenceManager` instance are evicted from the `IonSchemaSystem`'s `SchemaCache` so that the `SchemaCache` isn't polluted with unresolved/invalid schemas. The same schemas are also evicted from the `SchemaContentCache` so that if they get changed on disk, they can be reloaded properly.

The new implementation intentionally ignores the problem of cycles that are created using transitive imports. It is possible that this may work for some transitive import cycles, but that was a non-goal of this PR.

#### Description of changes in this PR:

 * Adds `DeferredReferenceManager` and `SchemaContentCache`
 * Also adds the data types that these classes manage
 * Also adds unit tests

### Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:

None.

----

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
