### PR TITLE
Consolidates version marker detection logic in IonSchemaVersion

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaVersion.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/IonSchemaVersion.kt
@@ -16,6 +16,9 @@
 package com.amazon.ionschema
 
 import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 enum class IonSchemaVersion(val symbolText: String) {
     v1_0("\$ion_schema_1_0"),
@@ -24,7 +27,17 @@ enum class IonSchemaVersion(val symbolText: String) {
     companion object {
         internal fun fromIonSymbolOrNull(symbol: IonSymbol): IonSchemaVersion? = values().singleOrNull { it.symbolText == symbol.stringValue() }
 
+        /**
+         * Tests if the IonValue is a value that is reserved for version markers, as per
+         * [ISL Versioning](https://amazon-ion.github.io/ion-schema/docs/isl-versioning#ion-schema-version-markers).
+         */
+        @OptIn(ExperimentalContracts::class)
+        internal fun isVersionMarker(value: IonValue): Boolean {
+            contract { returns(true) implies (value is IonSymbol) }
+            return value is IonSymbol && !value.isNullValue && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())
+        }
+
         @JvmStatic
-        internal val VERSION_MARKER_REGEX = Regex("^\\\$ion_schema_\\d.*")
+        private val VERSION_MARKER_REGEX = Regex("^\\\$ion_schema_\\d.*")
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -15,7 +15,6 @@
 
 package com.amazon.ionschema.internal
 
-import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonSystem
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Authority
@@ -74,7 +73,7 @@ internal class IonSchemaSystemImpl(
         val isl = schemaIterator.use {
             it.asSequence()
                 .onEach {
-                    if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                    if (IonSchemaVersion.isVersionMarker(it)) {
                         version = IonSchemaVersion.fromIonSymbolOrNull(it)
                             ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                     }
@@ -100,7 +99,7 @@ internal class IonSchemaSystemImpl(
         var version = IonSchemaVersion.v1_0
         val islList = isl.asSequence()
             .onEach {
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     version = IonSchemaVersion.fromIonSymbolOrNull(it) ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                 }
             }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContent.kt
@@ -40,7 +40,7 @@ internal class SchemaContent(val isl: List<IonValue>) {
         var version: IonSchemaVersion = IonSchemaVersion.v1_0
         declaredTypes = isl
             .onEach {
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     version = IonSchemaVersion.fromIonSymbolOrNull(it)
                         ?: throw InvalidSchemaException("Unsupported Ion Schema version: $it")
                 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
@@ -78,7 +78,7 @@ internal class SchemaImpl_1_0 private constructor(
 
                 dgIsl.add(it.clone())
 
-                if (it is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(it.stringValue())) {
+                if (IonSchemaVersion.isVersionMarker(it)) {
                     // This implementation only supports Ion Schema 1.0
                     if (it.stringValue() != "\$ion_schema_1_0") {
                         throw InvalidSchemaException("Unsupported Ion Schema version: ${it.stringValue()}")

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -107,7 +107,7 @@ internal class SchemaImpl_2_0 private constructor(
                 dgIsl.add(it.clone())
 
                 when {
-                    isVersionMarker(it) -> {
+                    IonSchemaVersion.isVersionMarker(it) -> {
                         islRequire(it.stringValue() == IonSchemaVersion.v2_0.symbolText) { "Unsupported Ion Schema version: $it" }
                         islRequire(!foundVersionMarker) { "Only one Ion Schema version marker is allowed in a schema document." }
                         islRequire(!foundHeader && !foundAnyType && !foundFooter) { "Ion Schema version marker must come before any header, types, and footer." }
@@ -184,7 +184,7 @@ internal class SchemaImpl_2_0 private constructor(
      * See https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#open-content
      */
     private fun isTopLevelOpenContent(value: IonValue): Boolean {
-        if (value is IonSymbol && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())) {
+        if (IonSchemaVersion.isVersionMarker(value)) {
             return false
         }
         if (value.typeAnnotations.any { IonSchema_2_0.RESERVED_WORDS_REGEX.matches(it) }) {
@@ -203,12 +203,6 @@ internal class SchemaImpl_2_0 private constructor(
     private fun isFooter(value: IonValue): Boolean {
         contract { returns(true) implies (value is IonStruct) }
         return value is IonStruct && !value.isNullValue && arrayOf("schema_footer").contentDeepEquals(value.typeAnnotations)
-    }
-
-    @OptIn(ExperimentalContracts::class)
-    private fun isVersionMarker(value: IonValue): Boolean {
-        contract { returns(true) implies (value is IonSymbol) }
-        return value is IonSymbol && !value.isNullValue && IonSchemaVersion.VERSION_MARKER_REGEX.matches(value.stringValue())
     }
 
     @OptIn(ExperimentalContracts::class)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaVersionTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaVersionTest.kt
@@ -2,8 +2,12 @@ package com.amazon.ionschema
 
 import com.amazon.ion.system.IonSystemBuilder
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 class IonSchemaVersionTest {
 
@@ -25,5 +29,34 @@ class IonSchemaVersionTest {
     fun `fromIonSymbolOrNull should return null for any other symbol`() {
         val islVersionSymbol = ION.newSymbol("\$ion_schema_0_1")
         assertNull(IonSchemaVersion.fromIonSymbolOrNull(islVersionSymbol))
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "\$ion_schema_1_0",
+            "\$ion_schema_2_0",
+            "\$ion_schema_0_1",
+            "\$ion_schema_0_1_2_3",
+            "\$ion_schema_0_abc",
+            "\$ion_schema_0",
+        ]
+    )
+    fun `isVersionMarker() should recognize symbols that are reserved for version markers`(ion: String) {
+        assertTrue(IonSchemaVersion.isVersionMarker(ION.singleValue(ion)))
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "\$ion_schema_a",
+            "\$ion_schema",
+            "\"\$ion_schema_1_0\"",
+            "null.symbol",
+            "\$ion_schema_1_0::null.symbol"
+        ]
+    )
+    fun `isVersionMarker() should reject values that are not reserved for version markers`(ion: String) {
+        assertFalse(IonSchemaVersion.isVersionMarker(ION.singleValue(ion)))
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

I discovered more inconsistencies with version marker detection, so we're revisiting this... again.
* Adds isVersionMarker(IonValue) to IonSchemaVersion and corresponding unit tests
* Replaces conditional checks in other part of the code with the new function

*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
