### PR TITLE
Wires the DeferredReferenceManager through all of the existing code

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactory.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ConstraintFactory.kt
@@ -32,5 +32,5 @@ internal interface ConstraintFactory {
      * @param[ion] IonValue identifying the constraint to construct as well as its configuration
      * @param[schema] passed to constraints that require a schema object
      */
-    fun constraintFor(ion: IonValue, schema: SchemaInternal): Constraint
+    fun constraintFor(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager): Constraint
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
@@ -43,12 +43,14 @@ internal class SchemaCore(
             .associateBy({ it.stringValue() }, { newType(it) })
             .toMutableMap()
 
-        ION.iterate(ADDITIONAL_TYPE_DEFS)
-            .asSequence()
-            .map { (it as IonStruct).first() }
-            .forEach {
-                typeMap.put(it.fieldName, TypeBuiltinImpl(it as IonStruct, this))
-            }
+        schemaSystem.usingReferenceManager { referenceManager ->
+            ION.iterate(ADDITIONAL_TYPE_DEFS)
+                .asSequence()
+                .map { (it as IonStruct).first() }
+                .forEach {
+                    typeMap.put(it.fieldName, TypeBuiltinImpl(it as IonStruct, this, referenceManager))
+                }
+        }
 
         isl = ION.newDatagram().markReadOnly()
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeBuiltinImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeBuiltinImpl.kt
@@ -31,8 +31,8 @@ internal class TypeBuiltinImpl private constructor(
     private val delegate: TypeInternal
 ) : TypeInternal by delegate, ConstraintBase(ion), TypeBuiltin {
 
-    constructor (ionStruct: IonStruct, schema: SchemaInternal) :
-        this(ionStruct, TypeImpl(ionStruct, schema, addDefaultTypeConstraint = false))
+    constructor (ionStruct: IonStruct, schema: SchemaInternal, referenceManager: DeferredReferenceManager) :
+        this(ionStruct, TypeImpl(ionStruct, schema, referenceManager, addDefaultTypeConstraint = false))
 
     override val name: String = ion.fieldName
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
@@ -33,6 +33,7 @@ import com.amazon.ionschema.internal.util.markReadOnly
 internal class TypeImpl(
     private val ionStruct: IonStruct,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
     addDefaultTypeConstraint: Boolean = true
 ) : TypeInternal, ConstraintBase(ionStruct) {
 
@@ -50,13 +51,13 @@ internal class TypeImpl(
         constraints = ionStruct.asSequence()
             .filter { it.fieldName == null || schema.getSchemaSystem().isConstraint(it.fieldName, schema) }
             .onEach { if (it.fieldName == "type") { foundTypeConstraint = true } }
-            .map { (schema.getSchemaSystem()).constraintFor(it, schema) }
+            .map { schema.getSchemaSystem().constraintFor(it, schema, referenceManager) }
             .toMutableList()
 
         if (schema.ionSchemaLanguageVersion == IonSchemaVersion.v1_0) {
             if (!foundTypeConstraint && addDefaultTypeConstraint) {
                 // default type for ISL 1.0 is 'any':
-                constraints.add(TypeReference.create(ANY, schema)())
+                constraints.add(TypeReference.create(ANY, schema, referenceManager)())
             }
         }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInline.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInline.kt
@@ -29,8 +29,8 @@ internal class TypeInline private constructor (
     private val type: TypeInternal
 ) : ConstraintBase(ion), TypeInternal by type {
 
-    constructor(ionStruct: IonStruct, schema: SchemaInternal) :
-        this(ionStruct, TypeImpl(ionStruct, schema))
+    constructor(ionStruct: IonStruct, schema: SchemaInternal, referenceManager: DeferredReferenceManager) :
+        this(ionStruct, TypeImpl(ionStruct, schema, referenceManager))
 
     override val name = type.name
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Annotations_2_0.kt
@@ -22,6 +22,7 @@ import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.CommonViolations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeInternal
 import com.amazon.ionschema.internal.TypeReference
@@ -37,6 +38,7 @@ import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 internal class Annotations_2_0 constructor(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
     private val type: () -> TypeInternal
@@ -76,9 +78,9 @@ internal class Annotations_2_0 constructor(
                 }
             }
 
-            TypeReference.create(annotationListTypeIon, schema)
+            TypeReference.create(annotationListTypeIon, schema, referenceManager)
         } else {
-            TypeReference.create(ion, schema, isField = true)
+            TypeReference.create(ion, schema, referenceManager, isField = true)
         }
     }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Element.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Element.kt
@@ -21,6 +21,7 @@ import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 import com.amazon.ionschema.internal.TypeReference.Companion.DEFAULT_ALLOWED_ANNOTATIONS
@@ -35,9 +36,10 @@ import com.amazon.ionschema.internal.util.islRequire
 internal class Element(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
-    private val typeReference = TypeReference.create(ion, schema, isField = true, allowedAnnotations = DEFAULT_ALLOWED_ANNOTATIONS + "distinct")
+    private val typeReference = TypeReference.create(ion, schema, referenceManager, isField = true, allowedAnnotations = DEFAULT_ALLOWED_ANNOTATIONS + "distinct")
     private val requireDistinctValues: Boolean
 
     init {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/FieldNames.kt
@@ -20,6 +20,7 @@ import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 
@@ -29,9 +30,9 @@ import com.amazon.ionschema.internal.TypeReference
  *
  * @see https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#field_names
  */
-internal class FieldNames(ion: IonValue, schema: SchemaInternal) : ConstraintBase(ion) {
+internal class FieldNames(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager) : ConstraintBase(ion) {
 
-    private val fieldNameType = TypeReference.create(ion.clone(), schema, isField = true, allowedAnnotations = setOf("distinct"))
+    private val fieldNameType = TypeReference.create(ion.clone(), schema, referenceManager, isField = true, allowedAnnotations = setOf("distinct"))
     private val requireDistinctValues: Boolean = ion.hasTypeAnnotation("distinct")
 
     override fun validate(value: IonValue, issues: Violations) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
@@ -23,6 +23,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.Constraint
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.constraint.Occurs.Companion.OPTIONAL
 import com.amazon.ionschema.internal.util.islRequire
@@ -40,6 +41,7 @@ import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 internal class Fields(
     ionValue: IonValue,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ionValue), Constraint {
 
     private val ionStruct: IonStruct
@@ -63,7 +65,7 @@ internal class Fields(
         // Forces the field definitions to be validated
         fieldConstraints = ionStruct.associateBy(
             { it.fieldName },
-            { Occurs(it, schema, OPTIONAL, isField = true) }
+            { Occurs(it, schema, referenceManager, OPTIONAL, isField = true) }
         )
 
         if (schema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Occurs.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Occurs.kt
@@ -24,6 +24,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.Constraint
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeInternal
 import com.amazon.ionschema.internal.TypeReference
@@ -46,6 +47,7 @@ import com.amazon.ionschema.internal.util.RangeType
 internal class Occurs(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
     defaultRange: Range<Int>,
     isField: Boolean = false
 ) {
@@ -108,7 +110,7 @@ internal class Occurs(
         } else {
             ion
         }
-        typeReference = TypeReference.create(tmpIon, schema, isField, variablyOccurring = true)
+        typeReference = TypeReference.create(tmpIon, schema, referenceManager, isField, variablyOccurring = true)
 
         occursIon =
             if (occurs != null) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/OrderedElements.kt
@@ -23,6 +23,7 @@ import com.amazon.ionschema.IonSchemaVersion.v2_0
 import com.amazon.ionschema.Violation
 import com.amazon.ionschema.ViolationChild
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 import com.amazon.ionschema.internal.util.IntRange
@@ -39,6 +40,7 @@ import com.amazon.ionschema.internal.util.schemaTypeName
 internal class OrderedElements(
     ion: IonValue,
     private val schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
     private val nfa: NFA<IonValue, Violation> = run {
@@ -50,7 +52,7 @@ internal class OrderedElements(
         val stateBuilder = OrderedElementsNfaStatesBuilder()
         ion.forEachIndexed { idx, it ->
             val occursRange = IntRange.toIntRange((it as? IonStruct)?.get("occurs")) ?: IntRange.REQUIRED
-            val typeRef = TypeReference.create(it, schema, variablyOccurring = true)
+            val typeRef = TypeReference.create(it, schema, referenceManager, variablyOccurring = true)
             stateBuilder.addState(
                 min = occursRange.lower,
                 max = occursRange.upper,

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Type.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Type.kt
@@ -17,6 +17,7 @@ package com.amazon.ionschema.internal.constraint
 
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
 import com.amazon.ionschema.internal.TypeReference
 
@@ -28,9 +29,10 @@ import com.amazon.ionschema.internal.TypeReference
 internal class Type(
     ion: IonValue,
     schema: SchemaInternal,
+    referenceManager: DeferredReferenceManager,
 ) : ConstraintBase(ion) {
 
-    private val typeReference = TypeReference.create(ion, schema)
+    private val typeReference = TypeReference.create(ion, schema, referenceManager)
 
     override fun validate(value: IonValue, issues: Violations) = typeReference().validate(value, issues)
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OrderedElementsTest.kt
@@ -30,7 +30,7 @@ class OrderedElementsTest {
     @ParameterizedTest(name = "ordered_elements:{0} should {1} {2}")
     @MethodSource("testCases")
     fun test(ionText: String, ignored: String, value: String, expectValid: Boolean) {
-        val constraint = OrderedElements(ION.singleValue(ionText), ISS.newSchema())
+        val constraint = ISS.usingReferenceManager { OrderedElements(ION.singleValue(ionText), ISS.newSchema(), it) }
         val v = Violations()
         constraint.validate(ION.singleValue(value), v, debug = true)
         assertEquals(expectValid, v.isValid())
@@ -39,7 +39,7 @@ class OrderedElementsTest {
     @ParameterizedTest(name = "violations message - {0}")
     @MethodSource("messageTestCases")
     fun test_messages(_name: String, constraintIon: String, value: String, message: String) {
-        val constraint = OrderedElements(ION.singleValue(constraintIon), ISS.newSchema())
+        val constraint = ISS.usingReferenceManager { OrderedElements(ION.singleValue(constraintIon), ISS.newSchema(), it) }
         val v = Violations()
         constraint.validate(ION.singleValue(value), v, debug = true)
         // Trim all whitespace to normalize before comparing


### PR DESCRIPTION
**Issue #, if available:**

Continuation of #209 

**Description of changes:**

See #234 for overall strategy.

* This passes the `DeferredReferenceManager` through all of the existing code, but does not actually use it yet for creating type references.
* Most of the code changes are just function signatures getting an extra parameter for the `DeferredReferenceManager`.
* `IonSchemaSystemImpl` has new functions to help mediate between the caches and use the reference manager.
 


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
