### PR TITLE
Fixes cyclical import resolution for SchemaImpl_2_0 header imports

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ImportImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/ImportImpl.kt
@@ -21,14 +21,23 @@ import com.amazon.ionschema.Type
 
 /**
  * Implementation of [Import] for all user-provided ISL.
+ *
+ * This is no longer used to support any of the internal functionality of Ion Schema Kotlin. It exists only for the
+ * [Schema.getImports] and [Schema.getImport] functions.
+ *
+ * Do not call any functions of this class (directly or indirectly) from within the init block of _any_ [Schema]
+ * implementation. If you do, the call may fail, depending on the order that schema imports are resolved, which is not
+ * guaranteed to be stable.
+ *
+ * This class (and [Import]) should be removed in v2.0.0 in favor of a map of schemaId to [Type] (or similar).
  */
 internal class ImportImpl(
     override val id: String,
-    private val schema: Schema,
+    private val schemaProvider: () -> Schema,
     private val types: Map<String, Type>
 ) : Import {
 
-    override fun getSchema() = schema
+    override fun getSchema() = schemaProvider()
 
     override fun getType(name: String) = types[name]
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -42,6 +42,8 @@ internal class IonSchemaSystemImpl(
         IonSchemaVersion.v2_0 to SchemaCore(this, IonSchemaVersion.v2_0)
     )
 
+    internal fun getBuiltInTypesSchema(version: IonSchemaVersion) = schemaCores[version]!!
+
     private val schemaContentCache = SchemaContentCache(this::loadSchemaContent)
 
     // Set to be used to detect cycle in import dependencies
@@ -100,7 +102,7 @@ internal class IonSchemaSystemImpl(
     private fun createSchema(referenceManager: DeferredReferenceManager, version: IonSchemaVersion, schemaId: String?, isl: List<IonValue>): SchemaInternal {
         return when (version) {
             IonSchemaVersion.v1_0 -> SchemaImpl_1_0(referenceManager, this, schemaCores[version]!!, isl.iterator(), schemaId)
-            IonSchemaVersion.v2_0 -> SchemaImpl_2_0(referenceManager, this, schemaCores[version]!!, isl.iterator(), schemaId)
+            IonSchemaVersion.v2_0 -> SchemaImpl_2_0(referenceManager, this, isl, schemaId)
         }
     }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_1_0.kt
@@ -210,7 +210,7 @@ internal class SchemaImpl_1_0 private constructor(
                 }
             }
         return importsMap.mapValues {
-            ImportImpl(it.value.id, it.value.schema, it.value.types)
+            ImportImpl(it.value.id, { it.value.schema }, it.value.types)
         }
     }
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -26,7 +26,6 @@ import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.Schema
 import com.amazon.ionschema.Type
-import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.util.IonSchema_2_0
 import com.amazon.ionschema.internal.util.getFields
 import com.amazon.ionschema.internal.util.getIslOptionalField
@@ -43,22 +42,27 @@ import kotlin.contracts.contract
 /**
  * Implementation of [Schema] for Ion Schema 2.0.
  */
-internal class SchemaImpl_2_0 private constructor(
+internal class SchemaImpl_2_0 internal constructor(
     referenceManager: DeferredReferenceManager,
     private val schemaSystem: IonSchemaSystemImpl,
-    private val schemaCore: SchemaCore,
-    schemaContent: Iterator<IonValue>,
+    schemaContent: Iterable<IonValue>,
     override val schemaId: String?,
-    preloadedImports: Map<String, Import>,
-    preloadedUserReservedFields: UserReservedFields,
-    /*
-     * [types] is declared as a MutableMap in order to be populated DURING
+
+) : SchemaInternal {
+
+    override val isl: IonDatagram
+    override val ionSchemaLanguageVersion = IonSchemaVersion.v2_0
+
+    /**
+     * [importedTypes] is declared as a MutableMap in order to be populated DURING
      * INITIALIZATION ONLY.  This enables type B to find its already-loaded
-     * dependency type A.  After initialization, [types] is expected to
+     * dependency type A.  After initialization, [importedTypes] is expected to
      * be treated as immutable as required by the Schema interface.
      */
-    private val types: MutableMap<String, TypeInternal>,
-) : SchemaInternal {
+    private val importedTypes: MutableMap<String, TypeInternal> = mutableMapOf()
+    private val declaredTypes: MutableMap<String, TypeImpl> = mutableMapOf()
+    private var userReservedFields: UserReservedFields = UserReservedFields.NONE
+    private var imports: Map<String, Import> = emptyMap()
 
     /**
      * Represents the collection of symbols that are declared as user reserved fields for a schema.
@@ -71,43 +75,25 @@ internal class SchemaImpl_2_0 private constructor(
         }
     }
 
-    internal constructor(
-        referenceManager: DeferredReferenceManager,
-        schemaSystem: IonSchemaSystemImpl,
-        schemaCore: SchemaCore,
-        schemaContent: Iterator<IonValue>,
-        schemaId: String?
-    ) : this(referenceManager, schemaSystem, schemaCore, schemaContent, schemaId, emptyMap(), UserReservedFields.NONE, mutableMapOf())
-
     private val deferredTypeReferences = mutableListOf<TypeReferenceDeferred>()
 
-    override val isl: IonDatagram
-
-    private val imports: Map<String, Import>
-
-    private var userReservedFields: UserReservedFields = UserReservedFields.NONE
-
-    private val declaredTypes: Map<String, TypeImpl>
-
-    override val ionSchemaLanguageVersion: IonSchemaVersion
-        get() = IonSchemaVersion.v2_0
-
     init {
-        val dgIsl = schemaSystem.ionSystem.newDatagram()
+        if (schemaId != null) referenceManager.registerDependentSchema(schemaId)
+        isl = schemaSystem.ionSystem.newDatagram()
 
-        if (types.isEmpty()) {
+        var foundVersionMarker = false
+        var foundHeader = false
+        var foundFooter = false
+        var foundAnyType = false
 
-            var foundVersionMarker = false
-            var foundHeader = false
-            var foundFooter = false
-            var foundAnyType = false
-            var importsMap = emptyMap<String, Import>()
+        importedTypes += schemaSystem.getBuiltInTypesSchema(ionSchemaLanguageVersion)
+            .getDeclaredTypes()
+            .asSequence()
+            .associateBy { it.name }
 
-            while (schemaContent.hasNext()) {
-                val it = schemaContent.next()
-
-                dgIsl.add(it.clone())
-
+        schemaContent.mapTo(isl) { it.clone() }
+            .markReadOnly()
+            .forEach {
                 when {
                     IonSchemaVersion.isVersionMarker(it) -> {
                         islRequire(it.stringValue() == IonSchemaVersion.v2_0.symbolText) { "Unsupported Ion Schema version: $it" }
@@ -119,7 +105,7 @@ internal class SchemaImpl_2_0 private constructor(
                         if (!foundVersionMarker) throw IllegalStateException("SchemaImpl_2_0 should only be instantiated for an ISL 2.0 schema.")
                         islRequire(!foundAnyType) { "Schema header must appear before any types." }
                         islRequire(!foundHeader) { "Only one schema header is allowed in a schema document." }
-                        importsMap = loadHeaderImports(types, it)
+                        imports = loadHeaderImports(it, referenceManager)
                         userReservedFields = loadUserReservedFieldNames(it)
                         validateFieldNamesInHeader(it)
                         foundHeader = true
@@ -133,9 +119,7 @@ internal class SchemaImpl_2_0 private constructor(
                     isType(it) -> {
                         islRequire(!foundFooter) { "Types may not occur after the schema footer." }
                         it.getIslRequiredField<IonSymbol>("name")
-                        val newType = TypeImpl(it, this, referenceManager)
-                        islRequire(newType.name !in types.keys) { "Invalid duplicate type name: '${newType.name}'" }
-                        addType(types, newType)
+                        addType(declaredTypes, TypeImpl(it, this, referenceManager))
                         foundAnyType = true
                     }
                     isTopLevelOpenContent(it) -> {} // Fine; do nothing.
@@ -144,41 +128,10 @@ internal class SchemaImpl_2_0 private constructor(
                     }
                 }
             }
-            islRequire(foundFooter || !foundHeader) { "Found a schema_header, but not a schema_footer" }
 
-            resolveDeferredTypeReferences()
-            imports = importsMap
-        } else {
-            // in this case the new Schema is based on an existing Schema and the 'types'
-            // map was populated by the caller
-            schemaContent.forEach {
-                dgIsl.add(it.clone())
-            }
-            imports = preloadedImports
-            userReservedFields = preloadedUserReservedFields
-        }
+        islRequire(foundFooter || !foundHeader) { "Found a schema_header, but not a schema_footer" }
 
-        isl = dgIsl.markReadOnly()
-        declaredTypes = types.values.filterIsInstance<TypeImpl>().associateBy { it.name }
-
-        if (declaredTypes.isEmpty()) {
-            schemaSystem.emitWarning { "${WarningType.SCHEMA_HAS_NO_TYPES} -- '$schemaId'" }
-        }
-    }
-
-    private class SchemaAndTypeImports(val id: String, val schema: Schema) {
-        var types: MutableMap<String, TypeInternal> = mutableMapOf()
-
-        fun addType(name: String, type: TypeInternal) {
-            types[name]?.let {
-                if (it.schemaId != type.schemaId || it.isl != type.isl) {
-                    throw InvalidSchemaException("Duplicate imported type name/alias encountered: '$name'")
-                } else if (it is ImportedType && it.schemaId == it.importedFromSchemaId) {
-                    return@addType
-                }
-            }
-            types[name] = type
-        }
+        resolveDeferredTypeReferences()
     }
 
     /**
@@ -270,12 +223,9 @@ internal class SchemaImpl_2_0 private constructor(
     }
 
     private fun loadHeaderImports(
-        typeMap: MutableMap<String, TypeInternal>,
-        header: IonStruct
+        header: IonStruct,
+        referenceManager: DeferredReferenceManager,
     ): Map<String, Import> {
-
-        val importsMap = mutableMapOf<String, SchemaAndTypeImports>()
-        val importSet: MutableSet<String> = schemaSystem.getSchemaImportSet()
 
         val imports = header.getIslOptionalField<IonList>("imports")
             ?.islRequireElementType<IonStruct>(containerDescription = "imports list")
@@ -293,49 +243,41 @@ internal class SchemaImpl_2_0 private constructor(
 
             val importedSchemaId = idField.stringValue()
             // if Schema is importing itself then throw error
-            if (schemaId == importedSchemaId) {
-                throw InvalidSchemaException("Schema can not import itself: $it")
-            }
-            // if importSet has an import with this id then do not load schema again to break the cycle.
-            if (!importSet.contains(importedSchemaId)) {
+            islRequire(schemaId != importedSchemaId) { "Schema can not import itself: $it" }
+            islRequire(schemaSystem.doesSchemaDocumentExist(importedSchemaId)) { "No such schema: $importedSchemaId" }
 
-                // add current schema to importSet and continue loading current schema
-                importSet.add(importedSchemaId)
-                val importedSchema = runCatching { schemaSystem.loadSchema(importedSchemaId) }
-                    .getOrElse { e -> throw InvalidSchemaException("Unable to load schema '$importedSchemaId'; ${e.message}") }
-                importSet.remove(importedSchemaId)
-
-                val schemaAndTypes = importsMap.getOrPut(importedSchemaId) {
-                    SchemaAndTypeImports(importedSchemaId, importedSchema)
-                }
-
-                val typeName = typeField?.stringValue()
-                if (typeName != null) {
-                    var importedType = importedSchema.getDeclaredType(typeName)
-                        ?.toImportedType(importedSchemaId)
-
-                    importedType ?: throw InvalidSchemaException("Schema $importedSchemaId doesn't contain a type named '$typeName'")
-
-                    if (asField != null) {
-                        importedType = TypeAliased(asField, importedType)
+            when {
+                asField != null -> {
+                    if (schemaSystem.doesSchemaDeclareType(importedSchemaId, typeField!!)) {
+                        val deferred = referenceManager.createDeferredImportReference(importedSchemaId, typeField)
+                        val type = TypeAliased(asField, deferred)
+                        addType(importedTypes, type)
+                    } else {
+                        throw InvalidSchemaException("No such type $typeField in schema $importedSchemaId")
                     }
-                    addType(typeMap, importedType)
-                    schemaAndTypes.addType(asField?.stringValue() ?: typeName, importedType)
-                } else {
-                    val typesToAdd = importedSchema.getDeclaredTypes()
-
-                    typesToAdd.asSequence()
-                        .map { type -> type.toImportedType(importedSchemaId) }
-                        .forEach { type ->
-                            addType(typeMap, type)
-                            schemaAndTypes.addType(type.name, type)
-                        }
+                }
+                typeField != null -> {
+                    if (schemaSystem.doesSchemaDeclareType(importedSchemaId, typeField)) {
+                        val deferred = referenceManager.createDeferredImportReference(importedSchemaId, typeField)
+                        addType(importedTypes, deferred)
+                    } else {
+                        throw InvalidSchemaException("No such type $typeField in schema $importedSchemaId")
+                    }
+                }
+                else -> {
+                    schemaSystem.listDeclaredTypes(importedSchemaId).forEach { importedTypeName ->
+                        val deferred = referenceManager.createDeferredImportReference(importedSchemaId, importedTypeName)
+                        addType(importedTypes, deferred)
+                    }
                 }
             }
         }
-        return importsMap.mapValues {
-            ImportImpl(it.value.id, it.value.schema, it.value.types)
-        }
+        return importedTypes.values
+            .filterIsInstance<ImportedType>()
+            .groupBy { it.schemaId }
+            .mapValues { (id, importedTypes) ->
+                ImportImpl(id, { schemaSystem.loadSchema(id) }, importedTypes.associateBy { it.name })
+            }
     }
 
     override fun getImport(id: String) = imports[id]
@@ -352,28 +294,33 @@ internal class SchemaImpl_2_0 private constructor(
         }
     }
 
-    private fun addType(typeMap: MutableMap<String, TypeInternal>, type: TypeInternal) {
-        validateType(type)
+    private fun <T : Type> addType(types: MutableMap<String, T>, type: T) {
+        // If it's not a struct, then it's an imported type, and we only have a name symbol
+        if (type.isl is IonStruct) validateType(type)
+
         getType(type.name)?.let {
+            if (type !is ImportedType || it !is ImportedType) {
+                throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
+            }
+
             if (it.schemaId != type.schemaId || it.isl != type.isl) {
+                throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
+            } else if (it.importedFromSchemaId != type.importedFromSchemaId) {
                 throw InvalidSchemaException("Duplicate type name/alias encountered: '${it.name}'")
             }
         }
-        typeMap[type.name] = type
+        types[type.name] = type
     }
 
     override fun getInScopeType(name: String) = getType(name)
 
-    override fun getType(name: String) = schemaCore.getType(name) ?: types[name]
+    override fun getType(name: String) = importedTypes[name] ?: declaredTypes[name]
 
     override fun getDeclaredType(name: String) = declaredTypes[name]
 
     override fun getDeclaredTypes(): Iterator<TypeInternal> = declaredTypes.values.iterator()
 
-    override fun getTypes(): Iterator<TypeInternal> =
-        (schemaCore.getTypes().asSequence() + types.values.asSequence())
-            .filter { it is ImportedType || it is TypeImpl }
-            .iterator()
+    override fun getTypes(): Iterator<TypeInternal> = (declaredTypes.values + importedTypes.values.filterIsInstance<TypeBuiltin>()).iterator()
 
     override fun newType(isl: String) = newType(
         schemaSystem.ionSystem.singleValue(isl) as IonStruct
@@ -385,41 +332,27 @@ internal class SchemaImpl_2_0 private constructor(
     }
 
     override fun plusType(type: Type): Schema {
-        type as TypeInternal
         validateType(type)
 
-        // prepare ISL corresponding to the new Schema
-        // (might be simpler if IonDatagram.set(int, IonValue) were implemented,
-        // see https://github.com/amazon-ion/ion-java/issues/50)
-        val newIsl = schemaSystem.ionSystem.newDatagram()
+        val newIsl = mutableListOf<IonValue>()
         var newTypeAdded = false
         isl.forEachIndexed { idx, value ->
             if (!newTypeAdded) {
-                when {
-                    value is IonStruct
-                        && (value["name"] as? IonSymbol)?.stringValue().equals(type.name) -> {
-                        // new type replaces existing type of the same name
-                        newIsl.add(type.isl.clone())
-                        newTypeAdded = true
-                        return@forEachIndexed
-                    }
-                    (value is IonStruct && value.hasTypeAnnotation("schema_footer"))
-                        || idx == isl.lastIndex -> {
-                        newIsl.add(type.isl.clone())
-                        newTypeAdded = true
-                    }
+                if (isType(value) && (value["name"] as? IonSymbol)?.stringValue() == type.name) {
+                    // new type replaces existing type of the same name
+                    newIsl.add(type.isl.clone())
+                    newTypeAdded = true
+                    return@forEachIndexed
+                } else if (value.hasTypeAnnotation("schema_footer") || idx == isl.lastIndex) {
+                    newIsl.add(type.isl.clone())
+                    newTypeAdded = true
                 }
             }
             newIsl.add(value.clone())
         }
         if (!newTypeAdded) newIsl.add(type.isl.clone())
 
-        // clone the types map:
-        val preLoadedTypes = types.toMutableMap()
-        preLoadedTypes[type.name] = type
-        return schemaSystem.usingReferenceManager { referenceManager ->
-            SchemaImpl_2_0(referenceManager, schemaSystem, schemaCore, newIsl.iterator(), null, imports, userReservedFields, preLoadedTypes)
-        }
+        return schemaSystem.newSchema(newIsl.iterator())
     }
 
     override fun getSchemaSystem() = schemaSystem
@@ -437,29 +370,6 @@ internal class SchemaImpl_2_0 private constructor(
             throw InvalidSchemaException(
                 "Unable to resolve type reference(s): $unresolvedDeferredTypeReferences"
             )
-        }
-    }
-
-    /**
-     * Returns a new [ImportedType] instance that decorates [Type] so that it will
-     * log a transitive import warning every time it is used for validation.
-     */
-    private fun Type.toImportedType(importedFromSchemaId: String): ImportedType {
-        this@toImportedType as TypeInternal
-        return object : ImportedType, TypeInternal by this {
-            override fun validate(value: IonValue, issues: Violations) {
-                if (importedFromSchemaId != schemaId) {
-                    schemaSystem.emitWarning {
-                        warnInvalidTransitiveImport(this, this@SchemaImpl_2_0.schemaId)
-                    }
-                }
-                this@toImportedType.validate(value, issues)
-            }
-
-            override val schemaId: String
-                get() = this@toImportedType.schemaId!!
-            override val importedFromSchemaId: String
-                get() = importedFromSchemaId
         }
     }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -45,7 +45,7 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
     islVersion = v2_0,
     additionalFileFilter = {
         // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/209
-        !it.path.contains("cycles/")
+        !it.path.contains("cycles/inline_import")
     }
 )
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0_Test.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0_Test.kt
@@ -1,0 +1,203 @@
+package com.amazon.ionschema.internal
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import com.amazon.ionschema.IonSchemaTests
+import com.amazon.ionschema.IonSchemaVersion
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class SchemaImpl_2_0_Test {
+
+    val ISS = IonSchemaSystemBuilder.standard()
+        .allowTransitiveImports(false)
+        .addAuthority(IonSchemaTests.authorityFor(IonSchemaVersion.v2_0))
+        .build()
+
+    fun ionStream(vararg topLevelValues: String): List<IonValue> {
+        return topLevelValues.map { ISS.ionSystem.singleValue(it) }
+    }
+
+    fun ionStruct(ion: String) = ISS.ionSystem.singleValue(ion) as IonStruct
+
+    @Test
+    fun `newType(isl) should create a new Type instance without modifying the schema`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo, type: int }")
+        val newType = schema.newType("type::{ name: bar }")
+
+        val oldSchemaTypes = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedOldSchemaTypes = setOf("foo")
+        assertEquals(expectedOldSchemaTypes, oldSchemaTypes, "The original schema should not be modified.")
+    }
+
+    @Test
+    fun `plusType(type) should return a new schema instance that contains the new type and the types from the original schema`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val newType = schema.newType("type::{ name: bar }")
+        val newSchema = schema.plusType(newType)
+
+        val oldSchemaTypes = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedOldSchemaTypes = setOf("foo")
+        assertEquals(expectedOldSchemaTypes, oldSchemaTypes, "The original schema should not be modified.")
+
+        val newSchemaTypes = newSchema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expectedNewSchemaTypes = setOf("foo", "bar")
+        assertEquals(expectedNewSchemaTypes, newSchemaTypes)
+    }
+
+    @Test
+    fun `plusType(type) should return a new schema instance, replacing an existing type with the same name`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val newType = schema.newType("type::{ name: foo, type: string }")
+        val newSchema = schema.plusType(newType)
+
+        val oldFooTypeIsl = schema.getType("foo")?.isl
+        val expectedOldFooTypeIsl = ionStruct("type::{ name: foo }")
+        assertEquals(expectedOldFooTypeIsl, oldFooTypeIsl, "The 'foo' type in the original schema should not be modified.")
+
+        val newFooTypeIsl = newSchema.getType("foo")?.isl
+        val expectedNewFooTypeIsl = ionStruct("type::{ name: foo, type: string }")
+        assertEquals(expectedNewFooTypeIsl, newFooTypeIsl)
+    }
+
+    @Test
+    fun `getType(name) should return a declared type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        assertNotNull(schema.getType("foo"))
+    }
+
+    @Test
+    fun `getType(name) should return a built-in type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        assertNotNull(schema.getType("text"))
+    }
+
+    @Test
+    fun `getType(name) should return an imported type`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+        val type = schema.getType("positive_int")
+        assertNotNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should return a declared type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val type = schema.getDeclaredType("foo")
+        assertNotNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should not return a built-in type`() {
+        val schema = ISS.newSchema("\$ion_schema_2_0 type::{ name: foo }")
+        val type = schema.getDeclaredType("text")
+        assertNull(type)
+    }
+
+    @Test
+    fun `getDeclaredType() should not return an imported type`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+        val type = schema.getDeclaredType("positive_int")
+        assertNull(type)
+    }
+
+    @Test
+    fun `getDeclaredTypes() should return only top level types that are declared in the schema`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        )
+
+        val result = schema.getDeclaredTypes().asSequence().map { it.name }.toSet()
+        val expected = setOf("foo", "bar", "baz")
+
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `getTypes() should return built-in types and declared types`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+
+        val result = schema.getTypes().asSequence().map { it.name }.toSet()
+
+        assertTrue(result.containsAll(setOf("foo", "bar", "baz")), "Result should contain the declared types")
+        assertFalse(result.contains("positive_int"), "Result should not contain the imported types")
+        assertTrue(result.contains("text"), "Result should contain built-in types")
+    }
+
+    @Test
+    fun `getImports() should return the imports objects`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+        // Unfortunately, [ImportImpl] doesn't have a proper definition of equality, so we're converting to a
+        // Map<String, List<String>>> which is like a multimap of schemaId to type names imported from that schema.
+        assertEquals(
+            mapOf("util.isl" to setOf("positive_int")),
+            schema.getImports().asSequence().associate { it.id to it.getTypes().asSequence().map { it.name }.toSet() },
+        )
+    }
+
+    @Test
+    fun `getImport(id) should return the imports for the given schema`() {
+        val schema = ISS.newSchema(
+            ionStream(
+                "\$ion_schema_2_0",
+                """ schema_header::{ imports: [ { id: "util.isl" } ] } """,
+                "type::{ name: foo, type: positive_int }",
+                "type::{ name: bar }",
+                "type::{ name: baz }",
+                "schema_footer::{}",
+            ).iterator()
+        ) as SchemaImpl_2_0
+
+        val import = schema.getImport("util.isl")
+        assertNotNull(import)
+        // Unfortunately, [ImportImpl] doesn't have a proper definition of equality, so we're just comparing the type
+        // names in the import
+        assertEquals(
+            setOf("positive_int"),
+            import?.getTypes()?.asSequence()?.map { it.name }?.toSet(),
+        )
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

Continuation of fixing #209 

**Description of changes:**

For overall strategy, see #234 

* `SchemaImpl_2_0` gets a considerable rewrite of how imports are handled so that imported schemas can be lazily loaded. It uses the DeferredReferenceManager to create all imported type references. Also treats the core types as if they are imported (which they are) which cuts down on extra code branching.
* `ImportImpl` now resolves the schema lazily, so that we can load schemas in a loop rather than recursively. (This is what required the one-line change in `SchemaImpl_1_0`.)
* Adds `SchemaImpl_2_0_Test`
* Adds an `internal` function to get the core types for any supported ISL version to `IonSchemaSystemImpl`
* Updates `IonSchemaTestsRunner` so that it now runs the header import cycles tests for ISL 2.0.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
