### PR TITLE
Fixes cyclical import resolution for SchemaImpl_1_0 header imports

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -172,8 +172,6 @@ internal class IonSchemaSystemImpl(
 
     internal fun constraintFor(ion: IonValue, schema: SchemaInternal, referenceManager: DeferredReferenceManager) = constraintFactory.constraintFor(ion, schema, referenceManager)
 
-    internal fun getSchemaImportSet() = schemaImportSet
-
     internal fun emitWarning(lazyWarning: () -> String) {
         warnCallback.invoke(lazyWarning)
     }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
@@ -266,4 +266,12 @@ class SchemaTest {
         assertTrue(schemaCore.isl.isReadOnly)
         assertNull(schemaCore.isl.container)
     }
+
+    @Test
+    fun `when there is an unresolvable cyclic import, SchemaImpl_1_0 should throw IonSchemaException`() {
+        // I.e. it should not throw a IonSchemaException instead of a StackOverflowError
+        assertThrows<IonSchemaException> {
+            iss.loadSchema("schema/import/cycles/header_import_a.isl")
+        }
+    }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/SchemaTest.kt
@@ -269,7 +269,7 @@ class SchemaTest {
 
     @Test
     fun `when there is an unresolvable cyclic import, SchemaImpl_1_0 should throw IonSchemaException`() {
-        // I.e. it should not throw a IonSchemaException instead of a StackOverflowError
+        // I.e. it should throw a IonSchemaException instead of a StackOverflowError
         assertThrows<IonSchemaException> {
             iss.loadSchema("schema/import/cycles/header_import_a.isl")
         }


### PR DESCRIPTION
*Issue #, if available:*

Continuation of #209 

*Description of changes:*

For overall strategy, see #234

This is the the equivalent to #238, but this is for `SchemaImpl_1_0`.

* Gets rid of schemaImportSet in IonSchemaSystemImpl in favor of just catching a StackOverflowException.
* Updates import logic in SchemaImpl_1_0 to use new DeferredReferences, and fallback to the old logic if transitive imports are enabled.
* Updates IonSchemaTestsRunner to skip the imports/cycle tests when running tests with transitive import enabled
* Updates `ion-schema-tests` submodule to the latest commit
  * Skips an unrelated failing test for ISL 2.0.


*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*

See changed files for changes in ion-schema-tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
