### PR TITLE
Fixes cyclical import resolution for inline imports

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaCore.kt
@@ -81,7 +81,6 @@ internal class SchemaCore(
     override fun newType(isl: String) = throw UnsupportedOperationException()
     override fun newType(isl: IonStruct) = throw UnsupportedOperationException()
     override fun plusType(type: Type) = throw UnsupportedOperationException()
-    override fun addDeferredType(typeRef: TypeReferenceDeferred) = throw UnsupportedOperationException()
 }
 
 private const val CORE_TYPES =

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -75,8 +75,6 @@ internal class SchemaImpl_2_0 internal constructor(
         }
     }
 
-    private val deferredTypeReferences = mutableListOf<TypeReferenceDeferred>()
-
     init {
         if (schemaId != null) referenceManager.registerDependentSchema(schemaId)
         isl = schemaSystem.ionSystem.newDatagram()
@@ -130,8 +128,6 @@ internal class SchemaImpl_2_0 internal constructor(
             }
 
         islRequire(foundFooter || !foundHeader) { "Found a schema_header, but not a schema_footer" }
-
-        resolveDeferredTypeReferences()
     }
 
     /**
@@ -328,7 +324,6 @@ internal class SchemaImpl_2_0 internal constructor(
 
     override fun newType(isl: IonStruct): Type {
         return schemaSystem.usingReferenceManager { TypeImpl(isl, this, it) }
-            .also { resolveDeferredTypeReferences() }
     }
 
     override fun plusType(type: Type): Schema {
@@ -356,20 +351,4 @@ internal class SchemaImpl_2_0 internal constructor(
     }
 
     override fun getSchemaSystem() = schemaSystem
-
-    override fun addDeferredType(typeRef: TypeReferenceDeferred) {
-        deferredTypeReferences.add(typeRef)
-    }
-
-    private fun resolveDeferredTypeReferences() {
-        val unresolvedDeferredTypeReferences = deferredTypeReferences
-            .filterNot { it.attemptToResolve() }
-            .map { it.name }.toSet()
-
-        if (unresolvedDeferredTypeReferences.isNotEmpty()) {
-            throw InvalidSchemaException(
-                "Unable to resolve type reference(s): $unresolvedDeferredTypeReferences"
-            )
-        }
-    }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaInternal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaInternal.kt
@@ -26,8 +26,6 @@ import com.amazon.ionschema.Schema
 internal interface SchemaInternal : Schema {
     val schemaId: String?
 
-    fun addDeferredType(typeRef: TypeReferenceDeferred)
-
     /**
      * The in-scope types for a schema consist of the ISL core types, any types declared in that schema, and any types
      * that are imported to the schema. This function is intended for internal use only in order to detect naming

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -32,13 +32,7 @@ import org.junit.jupiter.api.DynamicTest.dynamicTest
 import org.junit.jupiter.api.assertThrows
 import java.io.File
 
-class IonSchemaTests_1_0 : TestFactory by IonSchemaTestsRunner(
-    islVersion = v1_0,
-    additionalFileFilter = {
-        // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/209
-        !it.path.contains("cycles/inline_import")
-    }
-)
+class IonSchemaTests_1_0 : TestFactory by IonSchemaTestsRunner(v1_0)
 
 class IonSchemaTests_1_0_transitive : TestFactory by IonSchemaTestsRunner(
     islVersion = v1_0,
@@ -47,16 +41,12 @@ class IonSchemaTests_1_0_transitive : TestFactory by IonSchemaTestsRunner(
     // Skip the tests for import cycles, since fixing cycles with transitive imports enabled is a non-goal.
     additionalFileFilter = {
         !it.path.contains("invalid_transitive_import") &&
-            !it.path.contains("import/cycles")
+            !it.path.contains("import/cycles/header_import")
     }
 )
 
 class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
     islVersion = v2_0,
-    additionalFileFilter = {
-        // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/209
-        !it.path.contains("cycles/inline_import")
-    },
     testNameFilter = {
         // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/237
         !it.contains("user_reserved_fields declaration may not have unexpected fields")


### PR DESCRIPTION
**Issue #, if available:**

Fixes #209 

**Description of changes:**

For overall strategy, see #234 

* `TypeReference.kt` is updated to use `DeferredReferenceManager` and `TypeReferenceDeferred` is removed. It's a slightly larger change than it maybe needed to be because I wanted to separate the inline import and the inline type definition cases into separate helper functions.
* `addDeferredType()` is removed from `SchemaInternal` and implementations as well as all other `TypeReferenceDeferred` code.
* Updates `IonSchemaTestsRunner` to no longer skip the inline imports cycle tests.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

Cyclic import tests for ISl 1.0: https://github.com/amazon-ion/ion-schema-tests/pull/48
The tests for ISl 2.0 are essentially the same.
These changes were already incorporated by updating the git submodule in #240 .

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
