### PR TITLE
Stop allowing illegal fields in user_reserved_fields declaration

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -172,6 +172,7 @@ internal class SchemaImpl_2_0 internal constructor(
         userContent ?: return UserReservedFields.NONE
 
         islRequireIonTypeNotNull<IonStruct>(userContent) { "'user_reserved_fields' must be a non-null struct" }
+        userContent.islRequireOnlyExpectedFieldNames(IonSchema_2_0.TOP_LEVEL_ANNOTATION_KEYWORDS)
         islRequire(userContent.typeAnnotations.isEmpty()) { "'user_reserved_fields' may not have any annotations" }
         return UserReservedFields(
             headerWords = loadUserReservedFieldsSubfield(userContent, "schema_header"),

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -45,13 +45,7 @@ class IonSchemaTests_1_0_transitive : TestFactory by IonSchemaTestsRunner(
     }
 )
 
-class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(
-    islVersion = v2_0,
-    testNameFilter = {
-        // Pending fix for https://github.com/amazon-ion/ion-schema-kotlin/issues/237
-        !it.contains("user_reserved_fields declaration may not have unexpected fields")
-    }
-)
+class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(v2_0)
 
 /**
  * Primary test runner for the file-based test suite.


### PR DESCRIPTION
**Issue #, if available:**

#237 

**Description of changes:**

Adds a check to validate the fields in the `user_reserved_fields` declaration.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

Test cases: https://github.com/amazon-ion/ion-schema-tests/pull/47

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._