### PR TITLE
Fix multiple bugs related to nullability annotations

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/DeferredReference.kt
@@ -73,12 +73,14 @@ internal interface DeferredReference : TypeInternal {
 
     companion object {
         private fun illegalMethodCallBeforeResolving(): Nothing {
-            throw IllegalStateException("This should be unreachable because this method should not be called before the call to DeferredReferenceManager.resolve() is complete.")
+            throw UnresolvedTypeReferenceException("This should be unreachable because this method should not be called before the call to DeferredReferenceManager.resolve() is complete.")
         }
     }
     override fun getBaseType(): TypeBuiltin = if (isResolved()) resolve().getBaseType() else illegalMethodCallBeforeResolving()
     override fun isValidForBaseType(value: IonValue): Boolean = if (isResolved()) resolve().isValidForBaseType(value) else illegalMethodCallBeforeResolving()
     override fun validate(value: IonValue, issues: Violations) = if (isResolved()) resolve().validate(value, issues) else illegalMethodCallBeforeResolving()
+
+    class UnresolvedTypeReferenceException(message: String) : IllegalStateException(message)
 }
 
 /**

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaContentCache.kt
@@ -18,6 +18,7 @@ package com.amazon.ionschema.internal
 import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.internal.util.withoutTypeAnnotations
 
 /**
  * A class that caches the uninterpreted content of a Schema document. This enables us to determine which types are
@@ -75,7 +76,7 @@ internal class SchemaContentCache constructor(
      * into this instance of [SchemaContentCache].
      */
     fun doesSchemaDeclareType(schemaId: String, typeId: IonSymbol): Boolean {
-        return runCatching { typeId in getSchemaContent(schemaId).declaredTypes }.getOrElse { false }
+        return runCatching { typeId.withoutTypeAnnotations() in getSchemaContent(schemaId).declaredTypes }.getOrElse { false }
     }
 
     /**

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/Fields.kt
@@ -25,7 +25,6 @@ import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.Constraint
 import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
-import com.amazon.ionschema.internal.constraint.Occurs.Companion.OPTIONAL
 import com.amazon.ionschema.internal.util.islRequire
 import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 
@@ -65,7 +64,7 @@ internal class Fields(
         // Forces the field definitions to be validated
         fieldConstraints = ionStruct.associateBy(
             { it.fieldName },
-            { Occurs(it, schema, referenceManager, OPTIONAL, isField = true) }
+            { Occurs(it, schema, referenceManager, isField = true) }
         )
 
         if (schema.ionSchemaLanguageVersion >= IonSchemaVersion.v2_0) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
@@ -24,9 +24,9 @@ import com.amazon.ion.IonValue
  * If this value has no annotations, returns `this`;
  * otherwise, returns a clone of `this` with the annotations removed.
  */
-internal fun IonValue.withoutTypeAnnotations() =
+internal fun <T : IonValue> T.withoutTypeAnnotations(): T =
     if (typeAnnotations.isNotEmpty()) {
-        clone().apply { clearTypeAnnotations() }
+        clone().apply { clearTypeAnnotations() } as T
     } else {
         this
     }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #246 

**Description of changes:**

Basically, when constructing a `TypeNullable`, in the `init` block, it tries to check the Ion type of the type that it is decorating. If it determines that the Ion type is `IonType.DATAGRAM`, it throws an exception because there is no such thing as a null datagram. There is no nice way to fix this, so this errs on the side of being overly permissive—if we run into an unresolved type reference, the `TypeNullable` initializer swallows the exception and just moves on.

While I was working on this, I also discovered that `ion-schema-kotlin` is incorrectly allowing `nullable::` and `$null_or::` annotations on variably occurring type definitions (i.e. types with `occurs` in them), so I fixed that as well as refactoring `Occurs` while I was in there.

See 🗺️ comments for details about specific code changes.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

https://github.com/amazon-ion/ion-schema-tests/pull/49


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
