### PR TITLE
Adds the framework pieces for an Ion Schema reader that uses the ISL model

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/InvalidSchemaException.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/InvalidSchemaException.kt
@@ -15,7 +15,28 @@
 
 package com.amazon.ionschema
 
+import com.amazon.ionschema.reader.internal.ReadError
+
 /**
  * Thrown when an invalid schema definition is encountered.
  */
-class InvalidSchemaException(message: String) : IonSchemaException(message)
+class InvalidSchemaException(message: String) : IonSchemaException(message) {
+
+    /**
+     * Indicates whether this exception is a fail-fast exception (i.e. it should not be caught by any error collectors
+     * in an Ion Schema reader).
+     */
+    private var failFast = false
+    internal fun isFailFast() = failFast
+
+    companion object {
+        /**
+         * Factory function to create and throw a fail-fast [IonSchemaException] from a [ReadError].
+         */
+        internal fun failFast(error: ReadError): Nothing {
+            val e = InvalidSchemaException(error.message)
+            e.failFast = true
+            throw e
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
@@ -1,0 +1,64 @@
+package com.amazon.ionschema.reader
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.reader.internal.ReadError
+import com.amazon.ionschema.util.IonSchemaResult
+
+/**
+ * Reads IonValues into the Ion Schema model.
+ */
+@ExperimentalIonSchemaModel
+interface IonSchemaReader {
+    /**
+     * Attempts to read a [SchemaDocument]. Returns an [IonSchemaResult] containing either a [SchemaDocument] or a list
+     * of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readSchema(document: List<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>>
+
+    /**
+     * Reads a [SchemaDocument], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
+     * if the Ion value is not a valid Ion Schema Language schema document.
+     */
+    fun readSchemaOrThrow(document: List<IonValue>) = readSchema(document, true).unwrap()
+
+    /**
+     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema.
+     * Returns an [IonSchemaResult] containing either a [TypeDefinition] or a list of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<TypeDefinition, List<ReadError>>
+
+    /**
+     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema—
+     * throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException] if the Ion value is not a valid
+     * Ion Schema type definition.
+     */
+    fun readTypeOrThrow(ion: IonValue) = readType(ion, true).unwrap()
+
+    /**
+     * Reads a [NamedTypeDefinition]. Returns an [IonSchemaResult] containing either a [NamedTypeDefinition] or a list
+     * of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readNamedType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<NamedTypeDefinition, List<ReadError>>
+
+    /**
+     * Reads a [NamedTypeDefinition], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
+     * if the Ion value is not a valid Ion Schema named type definition.
+     */
+    fun readNamedTypeOrThrow(ion: IonValue) = readNamedType(ion, true).unwrap()
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonTreePath.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonTreePath.kt
@@ -1,0 +1,75 @@
+package com.amazon.ionschema.reader
+
+import com.amazon.ion.IonSequence
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+
+/**
+ * Represents a path through a tree of Ion values as a sequence of field names and indices.
+ *
+ * For example:
+ * ```ion
+ * type::{
+ *   name: foo,
+ *   fields: {
+ *     a: {
+ *       one_of: [
+ *         int,
+ *         string,  // The path from the top-level value (type::{ ... }) to this value is ('fields' 'a' 'one_of' 1)
+ *       ]
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * Be aware that there is ambiguity with field names because a struct can have more than one field with the same name.
+ */
+internal data class IonTreePath(val pathElements: List<Element>) : Comparable<IonTreePath> {
+
+    override fun compareTo(other: IonTreePath): Int {
+        val thisIter = this.pathElements.iterator()
+        val otherIter = other.pathElements.iterator()
+        while (thisIter.hasNext() && otherIter.hasNext()) {
+            val result = thisIter.next().compareTo(otherIter.next())
+            if (result != 0) return result
+        }
+        if (thisIter.hasNext()) return 1
+        if (otherIter.hasNext()) return -1
+        return 0
+    }
+
+    /**
+     * Represents a single element in an [IonTreePath]—either a [Index] or a [Field].
+     */
+    sealed class Element : Comparable<Element> {
+        data class Index(val value: Int) : Element()
+        data class Field(val value: String) : Element()
+
+        // Index before Field, otherwise compare the wrapped values
+        override fun compareTo(other: Element): Int {
+            return when (this) {
+                is Index -> if (other is Index) this.value.compareTo(other.value) else -1
+                is Field -> if (other is Field) this.value.compareTo(other.value) else if (other is Index) 1 else -1
+            }
+        }
+    }
+
+    companion object {
+        /**
+         * Factory function for creating an [IonTreePath] for an [IonValue]. This function follows [IonValue.getContainer]
+         * building the path until it gets to a value that does not have a parent container.
+         */
+        internal fun IonValue.treePath(): IonTreePath = IonTreePath(createPathElementList(this))
+
+        private fun createPathElementList(value: IonValue): MutableList<Element> {
+            val parent = value.container ?: return mutableListOf()
+            val path = createPathElementList(parent)
+            when (parent) {
+                is IonStruct -> path += Element.Field(value.fieldName)
+                is IonSequence -> path += Element.Index(parent.indexOf(value))
+                else -> TODO("Unreachable!")
+            }
+            return path
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReadError.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReadError.kt
@@ -1,0 +1,12 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.reader.IonTreePath.Companion.treePath
+
+/**
+ * Represents an error that occurred while attempting to read Ion as an Ion Schema value.
+ * The [value] is the IonValue where the error was detected, and [message] is a description of the problem.
+ */
+data class ReadError(val value: IonValue, val message: String) {
+    internal val path by lazy { value.treePath() }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReaderContext.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReaderContext.kt
@@ -1,0 +1,61 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.UserReservedFields
+
+/**
+ * Stores context that is used while reading Ion values as Ion Schema.
+ */
+@OptIn(ExperimentalIonSchemaModel::class)
+internal class ReaderContext(
+    /**
+     * The [UserReservedFields] of the current schema. Initially, this is an empty [UserReservedFields], but it can be
+     * mutated if a reader implementation encounters a schema header.
+     */
+    var userReservedFields: UserReservedFields = UserReservedFields(),
+    /**
+     * A list of [TypeArgument]s that are either a type name or an inline import that need to be resolved to an actual
+     * type if/when the schema or type being read is ever used for validation.
+     */
+    val unresolvedReferences: MutableList<TypeArgument> = mutableListOf(),
+    /**
+     * Indicates whether the reader implementation should fail on the first error it encounters or it should continue
+     * to try to report all errors.
+     */
+    val failFast: Boolean = false,
+) {
+    /**
+     * Flag to indicate whether a header has been found yet.
+     */
+    var foundHeader: Boolean = false
+    /**
+     * Flag to indicate whether any type definition has been found yet.
+     */
+    var foundAnyType: Boolean = false
+
+    /**
+     * A list of errors encountered while reading a schema or type.
+     */
+    private val _readErrors: MutableList<ReadError> = mutableListOf()
+
+    /**
+     * Public, non-mutable view of the [ReadError]s collected in this [ReaderContext].
+     */
+    val readErrors: List<ReadError>
+        get() = _readErrors.toList()
+
+    /**
+     * Reports a [ReadError] to this [ReaderContext].
+     * If [failFast] is false, adds an error to this [ReaderContext].
+     * If [failFast] is true, throws the error as an [InvalidSchemaException].
+     */
+    fun reportError(error: ReadError) {
+        if (failFast) {
+            InvalidSchemaException.failFast(error)
+        } else {
+            _readErrors.add(error)
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReader.kt
@@ -1,0 +1,41 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeArgumentList
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+
+@ExperimentalIonSchemaModel
+internal interface TypeReader {
+
+    /**
+     * Reads a [NamedTypeDefinition].
+     */
+    fun readNamedTypeDefinition(context: ReaderContext, ion: IonValue): NamedTypeDefinition
+
+    /**
+     * Reads a [TypeArgument].
+     */
+    fun readTypeArg(context: ReaderContext, ion: IonValue, checkAnnotations: Boolean = true): TypeArgument
+
+    /**
+     * Reads a [VariablyOccurringTypeArgument].
+     */
+    fun readVariablyOccurringTypeArg(context: ReaderContext, ion: IonValue, defaultOccurs: DiscreteIntRange): VariablyOccurringTypeArgument
+
+    /**
+     * Reads a [TypeArgumentList].
+     */
+    fun readTypeArgumentList(context: ReaderContext, ion: IonValue): TypeArgumentList {
+        val constraintName = ion.fieldName!!
+        islRequireIonTypeNotNull<IonList>(ion) { "Illegal argument for '$constraintName' constraint; must be non-null Ion list: $ion" }
+        islRequire(ion.typeAnnotations.isEmpty()) { "Illegal argument for '$constraintName' constraint; must not have annotations; was: $ion" }
+        return ion.readAllCatching(context) { readTypeArg(context, it) }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ConstraintReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ConstraintReader.kt
@@ -1,0 +1,22 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+
+/**
+ * Allows us to compose TypeReaders out of different combinations of constraint readers to enable code reuse across
+ * multiple Ion Schema versions.
+ */
+@ExperimentalIonSchemaModel
+internal interface ConstraintReader {
+
+    /**
+     * Contract—return null if and only if:
+     * - this ConstraintReader implementation does not handle the given field name _OR_
+     * - this ConstraintReader implementation does handle the given field name, but the value was not valid in some
+     *   way AND at least one error has been added to the context.
+     */
+    fun readConstraint(context: ReaderContext, constraintField: IonValue): Constraint?
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
@@ -1,0 +1,30 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+
+/**
+ * Helper function to catch exceptions and convert them into [ReadError] or rethrow if they are a fast-fail exception.
+ */
+@ExperimentalIonSchemaModel
+internal inline fun <T : Any> readCatching(context: ReaderContext, value: IonValue, block: () -> T?): T? {
+    return try {
+        block()
+    } catch (e: Exception) {
+        if (e is InvalidSchemaException && e.isFailFast()) {
+            throw e
+        } else {
+            context.reportError(ReadError(value, e.message ?: e.toString()))
+        }
+        null
+    }
+}
+
+/**
+ * Helper function to map a sequence of items, catching exceptions and convert them into [ReadError].
+ */
+@ExperimentalIonSchemaModel
+internal inline fun <T : Any> Iterable<IonValue>.readAllCatching(context: ReaderContext, crossinline block: (IonValue) -> T?): List<T> {
+    return mapNotNull { readCatching(context, it) { block(it) } }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/IonSchemaResult.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/IonSchemaResult.kt
@@ -1,0 +1,50 @@
+package com.amazon.ionschema.util
+
+import com.amazon.ionschema.IonSchemaException
+
+/**
+ * [IonSchemaResult] is a type that represents either success [Ok] or failure [Err].
+ */
+sealed class IonSchemaResult<T, E : Any> {
+    /**
+     * Gets the [Ok] result value. Throws an [IonSchemaException] if the result is [Err].
+     */
+    abstract fun unwrap(): T
+
+    /**
+     * Gets the [Ok] value or `null` if not [Ok].
+     */
+    fun okValueOrNull(): E? = (this as? Err)?.err
+
+    /**
+     * Gets the [Err] value or `null` if not an [Err].
+     */
+    fun errValueOrNull(): E? = (this as? Err)?.err
+
+    /**
+     * Returns `true` if the result is [Ok].
+     */
+    fun isOk() = this is Ok
+
+    /**
+     * Returns `true` if the result is [Err].
+     */
+    fun isErr() = this is Err
+
+    /**
+     * Contains the success value
+     */
+    data class Ok<T, E : Any>(internal val value: T) : IonSchemaResult<T, E>() {
+        override fun unwrap(): T = value
+    }
+
+    /**
+     * Contains the error value
+     */
+    data class Err<T, E : Any>(
+        val err: E,
+        internal var toException: (E) -> IonSchemaException = { IonSchemaException("$it") }
+    ) : IonSchemaResult<T, E>() {
+        override fun unwrap(): Nothing = throw toException(err)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/ReaderContextTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/ReaderContextTest.kt
@@ -1,0 +1,31 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.IonSchemaException
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+class ReaderContextTest {
+    companion object {
+        private val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `reportError() should throw when failFast is true`() {
+        val context = ReaderContext(failFast = true)
+        assertThrows<IonSchemaException> {
+            context.reportError(ReadError(ION.singleValue("-1"), "Warp drive setting must be positive."))
+        }
+    }
+
+    @Test
+    fun `reportError() should not throw when failFast is false`() {
+        val context = ReaderContext(failFast = false)
+        val error1 = ReadError(ION.singleValue("-1"), "Warp drive setting must be positive.")
+        val error2 = ReadError(ION.singleValue("11"), "Warp drive setting must be less than 10.")
+        context.reportError(error1)
+        context.reportError(error2)
+        assertEquals(listOf(error1, error2), context.readErrors)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/util/IonTreePathTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/util/IonTreePathTest.kt
@@ -1,0 +1,122 @@
+package com.amazon.ionschema.util
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonSexp
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.reader.IonTreePath
+import com.amazon.ionschema.reader.IonTreePath.Companion.treePath
+import com.amazon.ionschema.reader.IonTreePath.Element
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class IonTreePathTest {
+    companion object {
+        private val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `treePath() - root is sequence`() {
+        val list = ION.singleValue(
+            """
+          [
+            foo, bar, baz,
+            [
+              0, 1,
+              { 
+                a: { b: (c d e) } 
+              }
+            ]
+          ]
+        """
+        )
+        val value = (((((list as IonList)[3] as IonList)[2] as IonStruct)["a"] as IonStruct)["b"] as IonSexp)[1]
+
+        val path = value.treePath()
+        val expectedPath = IonTreePath(
+            listOf(
+                Element.Index(3),
+                Element.Index(2),
+                Element.Field("a"),
+                Element.Field("b"),
+                Element.Index(1),
+            )
+        )
+        assertEquals(expectedPath, path)
+    }
+
+    @Test
+    fun `treePath() - root is struct`() {
+        val dg = ION.singleValue(" { a: { b: (c d e) } } ")
+        val dSymbol = (((dg as IonStruct)["a"] as IonStruct)["b"] as IonSexp)[1]
+        val path = dSymbol.treePath()
+        val expectedPath = IonTreePath(
+            listOf(
+                Element.Field("a"),
+                Element.Field("b"),
+                Element.Index(1),
+            )
+        )
+        assertEquals(expectedPath, path)
+    }
+
+    @Test
+    fun `treePath() - root is scalar`() {
+        val value = ION.singleValue(" false ")
+        val path = value.treePath()
+        val expectedPath = IonTreePath(emptyList())
+        assertEquals(expectedPath, path)
+    }
+
+    @Test
+    fun `treePath() - path length of one`() {
+        val dg = ION.loader.load(" foo bar baz ")
+        val path = dg[1].treePath()
+        val expectedPath = IonTreePath(listOf(Element.Index(1)))
+        assertEquals(expectedPath, path)
+    }
+
+    @Test
+    fun `treePath() - empty path`() {
+        val ion = ION.singleValue("{}")
+        assertEquals(IonTreePath(emptyList()), ion.treePath())
+    }
+
+    @Test
+    fun `compareTo() - indices before fields`() {
+        val path1 = IonTreePath(listOf(Element.Field("foo"), Element.Index(1)))
+        val path2 = IonTreePath(listOf(Element.Field("foo"), Element.Field("1")))
+        assertTrue(path1 < path2)
+    }
+
+    @Test
+    fun `compareTo() - fields in string order`() {
+        val path1 = IonTreePath(listOf(Element.Field("a")))
+        val path2 = IonTreePath(listOf(Element.Field("b")))
+        assertTrue(path1 < path2)
+    }
+
+    @Test
+    fun `compareTo() - indices in numerical order`() {
+        val path1 = IonTreePath(listOf(Element.Index(1)))
+        val path2 = IonTreePath(listOf(Element.Index(2)))
+        assertTrue(path1 < path2)
+    }
+
+    @Test
+    fun `compareTo() - shorter is less than longer`() {
+        val path1 = IonTreePath(listOf())
+        val path2 = IonTreePath(listOf(Element.Index(1)))
+        assertTrue(path1 < path2)
+    }
+
+    @Test
+    fun `compareTo() - equal paths are equal`() {
+        val path1 = IonTreePath(listOf(Element.Field("foo"), Element.Index(1)))
+        val path2 = IonTreePath(listOf(Element.Field("foo"), Element.Index(1)))
+        assertFalse(path1 < path2)
+        assertFalse(path1 > path2)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**

Adds interfaces and common utilities for implementing an `IonSchemaReader` that will read Ion into the new ISL model. One improvement in particular over the existing reader logic *aside from the fact that this operates on the new model) is that this is designed to report multiple errors in a single schema document instead of just throwing an exception at the first error.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
