### PR TITLE
Adds CLI tool for fixing transitive imports

### DIFF
--- a/cli/build.gradle
+++ b/cli/build.gradle
@@ -26,11 +26,15 @@ repositories {
 
 dependencies {
     implementation project(':ion-schema')
-    implementation "com.amazon.ion:ion-java:[1.4,)"
+    implementation 'com.amazon.ion:ion-java:1.+'
+    implementation 'com.amazon.ion:ion-element:1.0.0'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
     implementation "com.github.ajalt.clikt:clikt:3.2.0"
     testImplementation "org.jetbrains.kotlin:kotlin-test:$kotlin_version"
     testImplementation 'io.kotest:kotest-assertions-core-jvm:[4.0,5.0['
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.2'
+    testImplementation 'org.junit.jupiter:junit-jupiter-params:5.6.2'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.6.2'
 }
 
 application {

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/Main.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/Main.kt
@@ -15,6 +15,7 @@
 
 package com.amazon.ionschema.cli
 
+import com.amazon.ionschema.cli.commands.RepairCommand
 import com.amazon.ionschema.cli.commands.ValidateCommand
 import com.github.ajalt.clikt.core.NoOpCliktCommand
 import com.github.ajalt.clikt.core.context
@@ -36,6 +37,7 @@ class IonSchemaCli : NoOpCliktCommand(
         context {
             subcommands(
                 ValidateCommand(),
+                RepairCommand(),
             )
             versionOption(getVersionString())
             helpFormatter = CliktHelpFormatter(showRequiredTag = true, showDefaultValues = true)

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/RepairCommand.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/RepairCommand.kt
@@ -1,0 +1,18 @@
+package com.amazon.ionschema.cli.commands
+
+import com.amazon.ionschema.cli.commands.repair.FixTransitiveImportsCommand
+import com.github.ajalt.clikt.core.NoOpCliktCommand
+import com.github.ajalt.clikt.core.context
+import com.github.ajalt.clikt.core.subcommands
+
+class RepairCommand : NoOpCliktCommand(
+    help = "Fixes schemas that are affected by a bug in some way."
+) {
+    init {
+        context {
+            subcommands(
+                FixTransitiveImportsCommand()
+            )
+        }
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/options.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/options.kt
@@ -78,7 +78,7 @@ fun CliktCommand.schemaOption() = mutuallyExclusiveOptions<IonSchemaSystem.() ->
  *
  * The delegated property has type `Schema.() -> Type`.
  */
-fun CliktCommand.typeArgument() = argument(help = "An ISL type name or inline type definition.")
+fun CliktCommand.typeArgument() = argument("TYPE", help = "An ISL type name or inline type definition.")
     .convert { createTypeLambdaForArgument(it) }
 
 private fun createTypeLambdaForArgument(typeArg: String): Schema.() -> Type {

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommand.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommand.kt
@@ -1,0 +1,99 @@
+package com.amazon.ionschema.cli.commands.repair
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.Authority
+import com.amazon.ionschema.AuthorityFilesystem
+import com.amazon.ionschema.IonSchemaSchemas
+import com.amazon.ionschema.cli.commands.authoritiesOption
+import com.amazon.ionschema.cli.commands.useIonSchemaSchemaAuthorityOption
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.arguments.convert
+import com.github.ajalt.clikt.parameters.options.convert
+import com.github.ajalt.clikt.parameters.options.default
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.types.enum
+import com.github.ajalt.clikt.parameters.types.file
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+
+class FixTransitiveImportsCommand : CliktCommand(
+    help = "Fixes schemas that are affected by the transitive import issue. See https://github.com/amzn/ion-schema/issues/39",
+    epilog = """
+        ```
+        Example usage:   
+            ion-schema-cli repair fix-transitive-imports cli/src/test/resources/FixTransitiveImportsCommand/input/
+        ```
+    """.trimIndent()
+) {
+
+    private val ion: IonSystem = IonSystemBuilder.standard().build()
+    private val fileSystemAuthorityRoots by authoritiesOption()
+    private val useIonSchemaSchemaAuthority by useIonSchemaSchemaAuthorityOption()
+
+    private val pathToFix by argument(
+        "BASE_DIRECTORY",
+        help = """
+        The path in which to fix schema files.
+        This path is implicitly used as an AuthorityFilesystem, so there is no need to also pass this path with the '-a' option.
+        """.trimIndent()
+    )
+        .file(mustExist = true, mustBeReadable = true, canBeFile = false).convert { it.path }
+
+    private val destination by option(
+        "-d", "--destination", metavar = "PATH",
+        help = """
+        A path for the new files to be written to.
+        This must be a writeable directory.
+        """.trimIndent()
+    ).file(canBeFile = false)
+        .convert<File, () -> String> { it::getPath }
+        .default(
+            { pathToFix + "_" + Instant.now().truncatedTo(ChronoUnit.SECONDS) },
+            defaultForHelp = "'<BASE_DIRECTORY>_<UTC_TIMESTAMP>'"
+        )
+
+    private val skipCleanup by option(help = "Skips cleanup of temp files—potentially useful for debugging problems.")
+        .flag(default = false)
+
+    private val verbose by option("-v", "--verbose").flag()
+
+    private val strategy by option(
+        "-s", "--strategy",
+        help = """
+        KeepWildcards -- While fixing imports, keeps all existing "wildcard" imports (i.e. `{id:<SCHEMA_ID>}`),
+        but all newly added imports will be type imports (i.e. `{id:<SCHEMA_ID>,type:<TYPE_NAME>}`).
+        This strategy will introduce smaller changes and will not introduce any naming conflicts.
+        However, the presence of wildcard imports means that unintentional name conflicts could happen in the future.
+        
+        NoWildcards -- While fixing imports, rewrite all imports as `{id:<SCHEMA_ID>,type:<TYPE_NAME>}`.
+        This may generate a larger diff, but it is guaranteed to never have name conflicts unintentionally 
+        introduced by a dependency in the future.
+        
+        PreferWildcards -- This strategy will cause the rewriter to prefer wildcard imports in the schema header.
+        This strategy may introduce name conflicts that result in an invalid schema. If that occurs, try again
+        using a different strategy.
+        """.trimIndent()
+    )
+        .enum<TransitiveImportRewriter.ImportStrategy>()
+        .default(TransitiveImportRewriter.ImportStrategy.KeepWildcards)
+
+    override fun run() {
+        val authorities = mutableListOf<Authority>()
+        if (useIonSchemaSchemaAuthority) authorities += IonSchemaSchemas.authority()
+        fileSystemAuthorityRoots.filter { it.path != pathToFix }
+            .mapTo(authorities) { AuthorityFilesystem(it.path) }
+
+        val destination = destination()
+        File(destination).let {
+            if (!it.exists()) it.mkdirs()
+            require(it.canWrite()) { "Cannot write to ${it.canonicalPath}" }
+        }
+
+        val rewriter = TransitiveImportRewriter(strategy, ion, skipCleanup, echo = if (verbose) ({ echo(it) }) else ({}))
+        rewriter.fixTransitiveImports(pathToFix, destination, authorities)
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/repair/TransitiveImportRewriter.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/commands/repair/TransitiveImportRewriter.kt
@@ -1,0 +1,380 @@
+package com.amazon.ionschema.cli.commands.repair
+
+import com.amazon.ion.IonSystem
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElementLoaderOptions
+import com.amazon.ionelement.api.IonLocation
+import com.amazon.ionelement.api.IonTextLocation
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.TextElement
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.loadAllElements
+import com.amazon.ionelement.api.location
+import com.amazon.ionelement.api.toIonElement
+import com.amazon.ionschema.Authority
+import com.amazon.ionschema.AuthorityFilesystem
+import com.amazon.ionschema.IonSchemaSystem
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import com.amazon.ionschema.Schema
+import com.amazon.ionschema.cli.util.PatchSet
+import com.amazon.ionschema.cli.util.PreOrder
+import com.amazon.ionschema.cli.util.createImportForType
+import com.amazon.ionschema.cli.util.findTypeReferences
+import com.amazon.ionschema.cli.util.forEachSchemaInPath
+import com.amazon.ionschema.cli.util.includesTypeImport
+import com.amazon.ionschema.cli.util.inferIndent
+import com.amazon.ionschema.cli.util.isBuiltInTypeName
+import com.amazon.ionschema.cli.util.recursivelyVisit
+import com.amazon.ionschema.cli.util.rewriteFile
+import java.io.File
+import java.time.Instant
+import java.util.Comparator
+
+class TransitiveImportRewriter(
+    private val importStrategy: ImportStrategy,
+    private val ionSystem: IonSystem = IonSystemBuilder.standard().build(),
+    private val skipCleanUp: Boolean,
+    private val echo: (String) -> Unit = {},
+) {
+
+    companion object {
+        /**
+         * Compares header import structs lexicographically by schemaId, then by type name, then by alias.
+         * Imports with no type name come before imports with a type name.
+         * Imports with no alias come before imports with an alias.
+         */
+        private val importComparator = Comparator.comparing<StructElement?, String?> { it["id"].textValue }
+            .thenBy { it.getOptional("type")?.textValue }
+            .thenBy { it.getOptional("as")?.textValue }
+    }
+
+    enum class ImportStrategy {
+        /**
+         * While fixing imports, rewrite all imports as `{ id: <SCHEMA_ID>, type: <TYPE_NAME> } `.
+         * You might find this style annoying, and it will possibly generate larger diff.
+         * However, it is guaranteed to never have name conflicts unintentionally introduced by a dependency in the future.
+         */
+        NoWildcards,
+        /**
+         * While fixing imports, keeps all existing "wildcard" imports (i.e. `{ id: <SCHEMA_ID> }`), but all new imports
+         * it adds will be type imports (i.e. `{ id: <SCHEMA_ID>, type: <TYPE_NAME> }`).
+         * This strategy will introduce smaller changes, and will not introduce any naming conflicts.
+         * However, the presence of wildcard imports means that unintentional name conflicts could happen in the future.
+         */
+        KeepWildcards,
+
+        /**
+         * While fixing imports, use only wildcard imports in the header, unless a type-specific import is required for
+         * a type alias. It is unlikely but possible that this strategy could introduce name conflicts, rendering the
+         * schema invalid. However, this tool will detect that during the final validation and throw an exception.
+         * If this strategy results in invalid schemas, use [KeepWildcards] or [NoWildcards] instead.
+         */
+        PreferWildcards,
+    }
+
+    /**
+     * Logic:
+     *
+     * ### Phase 0:
+     *
+     * Ensure all schemas load correctly using transitive imports before starting to fix the imports.
+     *
+     * ### Phase 1:
+     *
+     * For each file in base path, if it is an aggregator/export schema, rewrite it in temp directory, otherwise copy to
+     * temp directory unchanged.
+     *
+     * An "aggregator/export" schema is a schema that declares no types, but has types that are imported in the header.
+     * The only purpose for such a schema is to transitively re-export the types it imports—essentially a public API for
+     * a collection of schemas. We want to preserve the functionality of these schemas and any schemas that depend on
+     * them, so we rewrite these schemas first, and then rewrite all other schemas afterwards so that they can correctly
+     * resolve imports to these schemas.
+     *
+     * ### Phase 2:
+     *
+     * For each file in base path, if is an aggregator/export schema, copy to temp directory. Otherwise, check and
+     * resolve all header imports and inline imports. Also removes unused imports.
+     *
+     * ### Phase 3:
+     *
+     * Read all schemas in the new base path to make sure that they all load correctly, and then clean up all
+     * intermediate work.
+     */
+    fun fixTransitiveImports(basePath: String, newBasePath: String, authorities: List<Authority>) {
+        fun newIonSchemaSystem(basePath: String, withTransitiveImports: Boolean) = IonSchemaSystemBuilder.standard()
+            .allowTransitiveImports(withTransitiveImports)
+            .withIonSystem(ionSystem)
+            .withAuthorities(authorities)
+            .withAuthority(AuthorityFilesystem(basePath))
+            .build()
+
+        echo("Phase 0: Validate original schemas")
+        val issPhase0 = newIonSchemaSystem(basePath, withTransitiveImports = true)
+        forEachSchemaInPath(basePath) { id, _ -> issPhase0.loadSchema(id) }
+            .also(reportErrors("validate"))
+
+        echo("Phase 1: Rewrite aggregating schemas")
+        val newBasePathPhase1 = "$newBasePath/._rewriter_phase1_${Instant.now()}"
+        val issPhase1 = newIonSchemaSystem(basePath, withTransitiveImports = true)
+        forEachSchemaInPath(basePath) { schemaId, file ->
+            val patches = rewriteAggregatingSchema(schemaId, file, issPhase1)
+            rewriteFile(file, basePath, newBasePathPhase1, patches)
+        }.also(reportErrors("rewrite"))
+
+        echo("Phase 2: Rewrite all other schemas")
+        val newBasePathPhase2 = "$newBasePath/._rewriter_phase2_${Instant.now()}"
+        val issPhase2 = newIonSchemaSystem(newBasePathPhase1, withTransitiveImports = true)
+        forEachSchemaInPath(newBasePathPhase1) { schemaId, file ->
+            val patches = rewriteStandardSchema(schemaId, file, issPhase2)
+            rewriteFile(file, newBasePathPhase1, newBasePathPhase2, patches)
+        }.also(reportErrors("rewrite"))
+
+        echo("Phase 3: Validate new schemas")
+        val issPhase3 = newIonSchemaSystem(newBasePathPhase2, withTransitiveImports = false)
+        forEachSchemaInPath(newBasePathPhase2) { id, _ -> issPhase3.loadSchema(id) }
+            .also(reportErrors("validate"))
+
+        File(newBasePathPhase2).copyRecursively(File(newBasePath))
+        if (!skipCleanUp) {
+            File(newBasePathPhase1).deleteRecursively()
+            File(newBasePathPhase2).deleteRecursively()
+        }
+    }
+
+    private fun reportErrors(attemptedAction: String): (List<Pair<String, Throwable>>) -> Unit = { errs ->
+        errs.forEach { (s, t) -> echo("[\n  $s,\n  ${t.stackTraceToString()}\n]") }
+        if (errs.isNotEmpty()) {
+            val failureList = errs.joinToString("") { (k, v) -> "\n  [$k] ${v.message}," }
+            throw Exception("Failed to $attemptedAction:$failureList")
+        }
+    }
+
+    /**
+     * Replaces every type that is imported in the header with an explicit re-export of the type so that consumers of
+     * this schema can still access all the types without using transitive imports. I.e.:
+     * ```
+     * type::{ name:<ALIAS>, type: { id:<SCHEMA_ID>, type:<TYPE_NAME> } }
+     * ```
+     * See template in function body for details.
+     */
+    private fun rewriteAggregatingSchema(schemaId: String, schemaFile: File, iss: IonSchemaSystem): PatchSet {
+        val patchSet = PatchSet()
+        val schemaIslString = schemaFile.readText()
+
+        val schema = iss.newSchema(schemaIslString)
+        if (!isExportOnlySchema(schema)) return patchSet
+
+        val exports = schema.getTypes().asSequence()
+            .filter { !isBuiltInTypeName(it.name) && it.schemaId != null }
+            .map {
+                val alias = it.name
+                val name = it.isl.toIonElement().asStruct()["name"].textValue
+                val importedFromSchemaId = it.schemaId!!
+                ionStructOf(
+                    // alias and name could be the same value if there was no import alias
+                    // in which case it is being re-exported as the same name.
+                    "name" to ionSymbol(alias),
+                    "type" to ionStructOf(
+                        "id" to ionString(importedFromSchemaId),
+                        "type" to ionSymbol(name)
+                    ),
+                    annotations = listOf("type")
+                )
+            }
+            .sortedBy { it["name"].textValue }
+            .joinToString("\n")
+
+        patchSet.replaceAll(
+            """
+            |${'$'}ion_schema_1_0
+            |
+            |// Schema '$schemaId'
+            |// 
+            |// The purpose of this schema is to decouple consumers of the schema from the
+            |// implementation details (ie. specific locations) of each type that it provides,
+            |// and to indicate to consumers, which types they SHOULD use. Consumers of this
+            |// type CAN bypass this schema and import other types directly, but they SHOULD NOT
+            |// unless directed to do so by the owner(s)/author(s) of this schema.
+            |//
+            |// The type
+            |//     type::{name:foobar,type:{id:"bar.isl",type:foo}}
+            |// is analogous to
+            |//   [Javascript]: export { foo as foobar } from 'bar.isl'
+            |//         [Rust]: pub use bar::foo as foobar;
+            |
+            |
+            |$exports
+            |
+            """.trimMargin()
+        )
+        return patchSet
+    }
+
+    /**
+     * Checks all header imports and inline imports, resolving them to be direct imports instead of transitive imports.
+     */
+    private fun rewriteStandardSchema(schemaId: String, schemaFile: File, iss: IonSchemaSystem): PatchSet {
+        val patchSet = PatchSet()
+        val schema = iss.loadSchema(schemaId)
+
+        if (isExportOnlySchema(schema)) return patchSet
+
+        val headerImports: List<StructElement> = schema.isl
+            .singleOrNull { it.hasTypeAnnotation("schema_header") }?.toIonElement()
+            ?.asStruct()?.getOptional("imports")?.asList()?.values?.map { it.asStruct() }
+            ?: emptyList()
+
+        // Determine changes
+        val newHeaderImports = calculateNewHeaderImports(schema).sortedWith(importComparator)
+        val oldInlineImportsToNewInlineImportsMap = calculateNewInlineImportMapping(schemaId, iss)
+
+        // If no header and no changes to inline imports, do nothing
+        if (headerImports.isEmpty() && oldInlineImportsToNewInlineImportsMap.isEmpty()) {
+            return patchSet
+        }
+
+        // Generate Patch Set
+
+        // In order to make the least destructive possible diff, we load the Schema as raw Ion using the IonElement API.
+        // We find the text location of the values that need to be updated, and then apply the change to the original
+        // text of the file rather than modifying and writing the IonElement DOM. This allows us to preserve almost all
+        // comments and formatting.
+
+        val schemaIslString = schemaFile.readText()
+        val schemaIonElements = loadAllElements(schemaIslString, IonElementLoaderOptions(includeLocationMeta = true))
+
+        // IonElement provides row/col positions; get information to compute string index from row/col
+        val newlineLocations = schemaIslString.mapIndexedNotNull { i, c -> if (c == '\n') i else null }
+        val lineStartLocations = (listOf(0) + newlineLocations.map { it + 1 })
+        fun IonLocation?.toIndex(): Int = with(this as IonTextLocation) {
+            lineStartLocations[line.toInt() - 1] + charOffset.toInt() - 1
+        }
+
+        if (newHeaderImports != headerImports) {
+            schemaIonElements.singleOrNull { "schema_header" in it.annotations }
+                ?.let {
+                    val imports = it.asStruct().getOptional("imports")?.asList() ?: return@let
+                    if (imports.values.isEmpty()) return@let
+
+                    val importListStartLocation =
+                        schemaIslString.indexOf('[', startIndex = imports.metas.location.toIndex()) + 1
+                    val importListEndLocation =
+                        schemaIslString.indexOf(']', startIndex = imports.values.last().metas.location.toIndex()) - 1
+
+                    val replacementText = if (newHeaderImports.isEmpty()) {
+                        ""
+                    } else {
+                        val indent = schemaIslString.inferIndent() ?: "  "
+                        newHeaderImports.joinToString(separator = "") { "\n$indent$indent$it," } + "\n$indent"
+                    }
+                    patchSet.patch(importListStartLocation, importListEndLocation, replacementText)
+                }
+        }
+
+        // Patching the inline imports is a little easier. We will write the entire struct on a single line regardless
+        // of how they were first written so that we don't need to figure out the correct indentation.
+        val inlineImportPatchingVisitor = visitor@{ it: AnyElement ->
+            if (it is StructElement && oldInlineImportsToNewInlineImportsMap.containsKey(it) && oldInlineImportsToNewInlineImportsMap[it] != it) {
+                val start = schemaIslString.indexOf('{', startIndex = it.metas.location.toIndex())
+                val end = schemaIslString.indexOf("}", startIndex = start)
+                val replacementText = oldInlineImportsToNewInlineImportsMap[it].toString()
+                patchSet.patch(start, end, replacementText)
+            }
+        }
+        schemaIonElements.forEach { it.recursivelyVisit(PreOrder, inlineImportPatchingVisitor) }
+
+        return patchSet
+    }
+
+    /**
+     * Determines the new header imports for a schema.
+     */
+    private fun calculateNewHeaderImports(schema: Schema): List<StructElement> {
+        val headerImports: List<StructElement> = schema.isl
+            .singleOrNull { it.hasTypeAnnotation("schema_header") }?.toIonElement()
+            ?.asStruct()?.getOptional("imports")?.asList()?.values?.map { it.asStruct() }
+            ?: emptyList()
+
+        if (headerImports.isEmpty()) {
+            return emptyList()
+        }
+
+        // find all type arguments in the schema that are type names.
+        // If-and-only-if it is imported, create an import for it.
+        val actualImportedTypes = schema.isl
+            .filter { it.hasTypeAnnotation("type") }
+            .flatMap { findTypeReferences(it.toIonElement()) }
+            .asSequence()
+            .filterIsInstance<TextElement>()
+            .distinctBy { it.textValue }
+            // If it's declared in the same schema, we don't need to import it
+            .filter { schema.getDeclaredType(it.textValue) == null }
+            // If it's a built-in type, we don't need to import it
+            .filter { !isBuiltInTypeName(it.textValue) }
+            .map { schema.getType(it.textValue)!! }
+            .map { createImportForType(it) }
+            .toList()
+
+        return reconcileHeaderImports(headerImports, actualImportedTypes)
+    }
+
+    /**
+     * Returns a map of inline imports that need to be replaced, mapped to their replacement inline imports
+     */
+    private fun calculateNewInlineImportMapping(schemaId: String, iss: IonSchemaSystem): Map<StructElement, StructElement> {
+        val schema = iss.loadSchema(schemaId)
+        return schema.isl
+            .filter { it.hasTypeAnnotation("type") }
+            .flatMap { findTypeReferences(it.toIonElement()) }
+            .filterIsInstance<StructElement>() // Inline imports are structs, all other references are symbols
+            .associateWith {
+                val importedType = iss.loadSchema(it["id"].textValue).getType(it["type"].textValue)!!
+                createImportForType(importedType)
+            }
+            .filter { (old, new) -> old != new } // remove any identity transforms
+    }
+
+    /**
+     * Checks if a schema has at least one import, and has no declared types. I.e. its only purpose is to re-export other types.
+     */
+    private fun isExportOnlySchema(schema: Schema): Boolean {
+        return schema.getDeclaredTypes().asSequence().toList().isEmpty() &&
+            schema.getImports().hasNext()
+    }
+
+    /**
+     * Computes the minimal set of header imports for the actual imported types, given the Import reconciliation strategy.
+     */
+    private fun reconcileHeaderImports(headerImports: List<StructElement>, actualImportedTypes: List<StructElement>): List<StructElement> {
+        val newImports = mutableSetOf<StructElement>()
+        when (importStrategy) {
+            ImportStrategy.NoWildcards -> newImports.addAll(actualImportedTypes)
+            ImportStrategy.KeepWildcards -> {
+                headerImports.forEach { import ->
+                    if (actualImportedTypes.any { import includesTypeImport it } && import !in newImports) {
+                        newImports.add(import)
+                    }
+                }
+                actualImportedTypes.forEach { typeImport ->
+                    if (!newImports.any { it includesTypeImport typeImport } && typeImport !in newImports) {
+                        newImports.add(typeImport)
+                    }
+                }
+            }
+            ImportStrategy.PreferWildcards -> {
+                actualImportedTypes.forEach { typeImport ->
+                    if (typeImport.getOptional("as") != null) {
+                        newImports.add(typeImport)
+                    } else {
+                        val wildcard = ionStructOf("id" to typeImport["id"])
+                        if (wildcard !in newImports) newImports.add(wildcard)
+                    }
+                }
+            }
+        }
+        return newImports.toList()
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/util/PatchSet.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/util/PatchSet.kt
@@ -1,0 +1,28 @@
+package com.amazon.ionschema.cli.util
+
+import java.util.TreeSet
+
+class PatchSet {
+    private data class Patch(val start: Int, val endInclusive: Int, val replacementText: String)
+
+    private val patchSet = TreeSet<Patch>(compareByDescending { it.start })
+
+    fun hasChanges() = patchSet.isNotEmpty()
+
+    fun patch(start: Int, endInclusive: Int, replacementText: String) {
+        patchSet.add(Patch(start, endInclusive, replacementText))
+    }
+
+    fun replaceAll(newText: String) {
+        patchSet.add(Patch(0, -1, newText))
+    }
+
+    fun applyTo(original: String): String {
+        val sb = StringBuilder(original)
+        for ((start, endInclusive, newText) in patchSet) {
+            val endExclusive = if (endInclusive == -1) original.length else endInclusive + 1
+            sb.replace(start, endExclusive, newText)
+        }
+        return sb.toString()
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/util/files.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/util/files.kt
@@ -1,0 +1,65 @@
+package com.amazon.ionschema.cli.util
+
+import java.io.File
+
+/**
+ * Does some action for each `.isl` file that is in the given path
+ */
+fun forEachSchemaInPath(path: String, action: (schemaId: String, schemaFile: File) -> Unit): List<Pair<String, Throwable>> {
+    return File(path).walk()
+        .filter { it.isFile }
+        .filter { it.path.endsWith(".isl") }
+        .map { file -> file.path.substring(path.length + 1) to file }
+        .mapNotNull { (schemaId, file) ->
+            runCatching { action.invoke(schemaId, file) }
+                .exceptionOrNull()
+                ?.also { it.printStackTrace() }
+                ?.let { schemaId to it }
+        }.toList()
+}
+
+/**
+ * Copies a file from the current [basePath] to the [newBasePath], modifying the contents according to the given [patchSet].
+ */
+fun rewriteFile(file: File, basePath: String, newBasePath: String, patchSet: PatchSet) {
+    val schemaId = file.path.substring(basePath.length + 1)
+    val newFile = File("$newBasePath/$schemaId")
+    newFile.parentFile.mkdirs()
+    if (patchSet.hasChanges()) {
+        newFile.createNewFile()
+        val schemaIonText = file.readText(Charsets.UTF_8)
+        newFile.appendText(patchSet.applyTo(schemaIonText))
+    } else {
+        file.copyTo(newFile)
+    }
+}
+
+/**
+ * Attempts to detect the indentation of a multiline String.
+ */
+fun String.inferIndent(): String? {
+    fun String.indentWidth(): Int = indexOfFirst { !it.isWhitespace() }.let { if (it == -1) length else it }
+
+    val lineIndentation = lines()
+        .filter { it.isNotBlank() }
+        .mapNotNull {
+            if (it.startsWith(" ")) {
+                it.indentWidth()
+            } else if (it.startsWith("\t")) {
+                // Found a tab? Assume all indentation is with tabs.
+                return "\t"
+            } else {
+                null // No indentation on this line.
+            }
+        }
+
+    // If we're returning here, it's because there are no indented lines
+    val min = lineIndentation.minOfOrNull { it } ?: return null
+
+    return if (lineIndentation.all { it % min == 0 }) {
+        " ".repeat(min)
+    } else {
+        // Indentation is inconsistent -- cannot be determined
+        null
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/util/ion.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/util/ion.kt
@@ -1,0 +1,20 @@
+package com.amazon.ionschema.cli.util
+
+import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.ContainerElement
+import com.amazon.ionelement.api.IonElement
+
+sealed class TraversalOrder
+internal object PreOrder : TraversalOrder()
+internal object PostOrder : TraversalOrder()
+
+/**
+ * Visits every element contained in (and including) this [IonElement].
+ */
+internal fun IonElement.recursivelyVisit(order: TraversalOrder, visitor: (AnyElement) -> Unit) {
+    with(this.asAnyElement()) {
+        if (order is PreOrder) visitor(this)
+        if (this is ContainerElement) asContainerOrNull()?.values?.forEach { child -> child.recursivelyVisit(order, visitor) }
+        if (order is PostOrder) visitor(this)
+    }
+}

--- a/cli/src/main/kotlin/com/amazon/ionschema/cli/util/ionSchema.kt
+++ b/cli/src/main/kotlin/com/amazon/ionschema/cli/util/ionSchema.kt
@@ -1,0 +1,106 @@
+package com.amazon.ionschema.cli.util
+
+import com.amazon.ionelement.api.AnyElement
+import com.amazon.ionelement.api.IonElement
+import com.amazon.ionelement.api.StructElement
+import com.amazon.ionelement.api.SymbolElement
+import com.amazon.ionelement.api.ionString
+import com.amazon.ionelement.api.ionStructOf
+import com.amazon.ionelement.api.ionSymbol
+import com.amazon.ionelement.api.toIonElement
+import com.amazon.ionschema.Type
+
+/**
+ * Checks if a type name is one of the Ion Schema built in types.
+ */
+fun isBuiltInTypeName(name: String) = name in setOf(
+    "any", "\$any",
+    "blob", "\$blob",
+    "bool", "\$bool",
+    "clob", "\$clob",
+    "decimal", "\$decimal",
+    "document",
+    "float", "\$float",
+    "int", "\$int",
+    "list", "\$list",
+    "lob", "\$lob",
+    "nothing",
+    "\$null",
+    "number", "\$number",
+    "sexp", "\$sexp",
+    "string", "\$string",
+    "struct", "\$struct",
+    "symbol", "\$symbol",
+    "text", "\$text",
+    "timestamp", "\$timestamp",
+)
+
+/**
+ * Recursively finds all type references in an Ion Schema type definition.
+ */
+fun findTypeReferences(ionElement: IonElement): List<AnyElement> {
+    ionElement as AnyElement
+    return when {
+        ionElement.isInlineImport() -> listOf(ionElement)
+        ionElement is SymbolElement -> listOf(ionElement)
+        ionElement is StructElement -> {
+            ionElement.fields.flatMap {
+                when (it.name) {
+                    "type",
+                    "not",
+                    "element" -> findTypeReferences(it.value)
+                    "one_of",
+                    "any_of",
+                    "all_of",
+                    "ordered_elements",
+                    "fields" -> it.value.containerValues.flatMap { findTypeReferences(it) }
+                    else -> emptyList()
+                }
+            }
+        }
+        else -> emptyList()
+    }
+}
+
+/**
+ * Determines whether one header import subsumes another header import.
+ */
+infix fun StructElement.includesTypeImport(other: StructElement): Boolean {
+    return this["id"].textValue == other["id"].textValue &&
+        (this.getOptional("type") ?: other["type"]).textValue == other["type"].textValue &&
+        this.getOptional("as")?.textValue == other.getOptional("as")?.textValue
+}
+
+/**
+ * Checks whether an [IonElement] is an Ion Schema inline import
+ */
+fun IonElement.isInlineImport(): Boolean =
+    this is StructElement && this.fields.map { it.name }
+        .let { fieldNames -> "id" in fieldNames && "type" in fieldNames }
+
+/**
+ * Constructs a [StructElement] that is a valid Ion Schema import for the given [Type].
+ */
+fun createImportForType(type: Type): StructElement {
+    val alias = type.name
+
+    val typeIsl = type.isl.toIonElement()
+    val name = when (typeIsl) {
+        is StructElement -> typeIsl["name"].textValue
+        is SymbolElement -> typeIsl.textValue
+        else -> TODO("Unreachable!")
+    }
+    val importedFromSchemaId = type.schemaId!!
+    return if (alias != name) {
+        ionStructOf(
+            "id" to ionString(importedFromSchemaId),
+            "type" to ionSymbol(name),
+            "as" to ionSymbol(alias),
+        )
+    } else {
+        ionStructOf(
+            "id" to ionString(importedFromSchemaId),
+            "type" to ionSymbol(name),
+        )
+    }
+}

--- a/cli/src/test/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommandTest.kt
+++ b/cli/src/test/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommandTest.kt
@@ -1,0 +1,106 @@
+package com.amazon.ionschema.cli.commands.repair
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.cli.IonSchemaCli
+import com.amazon.ionschema.cli.commands.repair.TransitiveImportRewriter.ImportStrategy
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest.dynamicTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.TestFactory
+import org.junit.jupiter.api.TestInstance
+import java.io.File
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.stream.Stream
+
+class FixTransitiveImportsCommandTest {
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class NoWildcards {
+        @BeforeAll
+        fun runCommand() = runCommand(ImportStrategy.NoWildcards)
+        @TestFactory
+        fun testCases() = testForStrategy(ImportStrategy.NoWildcards)
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class KeepWildcards {
+        @BeforeAll
+        fun runCommand() = runCommand(ImportStrategy.KeepWildcards)
+        @TestFactory
+        fun testCases() = testForStrategy(ImportStrategy.KeepWildcards)
+    }
+
+    @Nested
+    @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+    inner class PreferWildcards {
+        @BeforeAll
+        fun runCommand() = runCommand(ImportStrategy.PreferWildcards)
+        @TestFactory
+        fun testCases() = testForStrategy(ImportStrategy.PreferWildcards)
+    }
+
+    companion object {
+        val ION = IonSystemBuilder.standard().build()
+        private val testResourceDir = File("src/test/resources").canonicalPath
+        private val baseOutputDir = File("build/tmp/test/").canonicalPath
+        val timestamp = Instant.now().truncatedTo(ChronoUnit.SECONDS)
+
+        private fun runCommand(strategy: ImportStrategy) {
+            val outputDir = File("$baseOutputDir/FixTransitiveImportsCommand/$strategy-test-output-$timestamp")
+            IonSchemaCli().parse(
+                arrayOf(
+                    "repair", "fix-transitive-imports",
+                    "-s", "$strategy",
+                    "-d", "$outputDir",
+                    "$testResourceDir/FixTransitiveImportsCommand/input/",
+                )
+            )
+        }
+
+        fun testForStrategy(strategy: ImportStrategy): Stream<DynamicNode> {
+
+            val outputDir = File("$baseOutputDir/FixTransitiveImportsCommand/$strategy-test-output-$timestamp")
+            val expectationDir = File("$testResourceDir/FixTransitiveImportsCommand/output-$strategy")
+
+            val testNodes = mutableListOf<DynamicNode>()
+            expectationDir.walk()
+                .filter { it.isFile }
+                .forEach { expectedFile ->
+                    val relativeFile = expectedFile.relativeTo(expectationDir)
+                    val actualFile = outputDir.resolve(relativeFile)
+
+                    // This should not be brittle, and should probably not require the expected outputs to be updated.
+                    testNodes.add(
+                        dynamicTest("Check $relativeFile are Ion equivalent", actualFile.toURI()) {
+                            Assertions.assertEquals(
+                                ION.loader.load(expectedFile),
+                                ION.loader.load(actualFile),
+                            )
+                        }
+                    )
+                    // This test could be brittle, but we need it to ensure (a) that we don't wipe out any comments in the
+                    // ISL, and (b) that we don't suddenly start making large style-related changes to the original files.
+                    // For some changes this test may fail, and sometimes we might want to update the expected outputs
+                    // (e.g. if there's some intended whitespace change).
+                    // To do so, run:
+                    // ./ion-schema-cli repair fix-transitive-imports -s <STRATEGY> \
+                    //     cli/src/test/resources/FixTransitiveImportsCommand/input/ \
+                    //     -d cli/src/test/resources/FixTransitiveImportsCommand/output-<STRATEGY>/
+                    testNodes.add(
+                        dynamicTest("Check $relativeFile are text equivalent", actualFile.toURI()) {
+                            Assertions.assertEquals(
+                                expectedFile.readText(),
+                                actualFile.readText(),
+                            )
+                        }
+                    )
+                }
+            return testNodes.stream()
+        }
+    }
+}

--- a/cli/src/test/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommandTest.kt
+++ b/cli/src/test/kotlin/com/amazon/ionschema/cli/commands/repair/FixTransitiveImportsCommandTest.kt
@@ -74,7 +74,7 @@ class FixTransitiveImportsCommandTest {
                     val relativeFile = expectedFile.relativeTo(expectationDir)
                     val actualFile = outputDir.resolve(relativeFile)
 
-                    // This should not be brittle, and should probably not require the expected outputs to be updated.
+                    // This should be robust, and should probably not require the expected outputs to be updated.
                     testNodes.add(
                         dynamicTest("Check $relativeFile are Ion equivalent", actualFile.toURI()) {
                             Assertions.assertEquals(
@@ -83,16 +83,17 @@ class FixTransitiveImportsCommandTest {
                             )
                         }
                     )
-                    // This test could be brittle, but we need it to ensure (a) that we don't wipe out any comments in the
+                    // This test could be fragile, but we need it to ensure (a) that we don't wipe out any comments in the
                     // ISL, and (b) that we don't suddenly start making large style-related changes to the original files.
                     // For some changes this test may fail, and sometimes we might want to update the expected outputs
                     // (e.g. if there's some intended whitespace change).
+                    // This could also fail if ion-java changes e.g. the amount of whitespace emitted by the text writer.
                     // To do so, run:
                     // ./ion-schema-cli repair fix-transitive-imports -s <STRATEGY> \
                     //     cli/src/test/resources/FixTransitiveImportsCommand/input/ \
                     //     -d cli/src/test/resources/FixTransitiveImportsCommand/output-<STRATEGY>/
                     testNodes.add(
-                        dynamicTest("Check $relativeFile are text equivalent", actualFile.toURI()) {
+                        dynamicTest("⚠Fragile⚠ Check $relativeFile are text equivalent", actualFile.toURI()) {
                             Assertions.assertEquals(
                                 expectedFile.readText(),
                                 actualFile.readText(),

--- a/cli/src/test/kotlin/com/amazon/ionschema/cli/util/filesTest.kt
+++ b/cli/src/test/kotlin/com/amazon/ionschema/cli/util/filesTest.kt
@@ -1,0 +1,68 @@
+package com.amazon.ionschema.cli.util
+
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+
+class DetectIndentTest {
+    @Test
+    fun `when no indentation should return null`() {
+        val text = """
+            |Lorem ipsum dolor englebert.
+            |
+            |Quando omni flunkus moritati.
+        """.trimMargin()
+        Assertions.assertEquals(null, text.inferIndent())
+    }
+
+    @Test
+    fun `when spaces indentation should return correct number of spaces`() {
+        val text = """
+            |type::{
+            |  name: positive_int,
+            |  type: int,
+            |  valid_values: range::[1, max],
+            |}
+        """.trimMargin()
+        Assertions.assertEquals("  ", text.inferIndent())
+    }
+
+    @Test
+    fun `when spaces indentation is inconsistent should return null`() {
+        val text = """
+            |type::{
+            |    name: positive_int,
+            |   type: int,
+            |     valid_values: range::[1, max],
+            |}
+        """.trimMargin()
+        Assertions.assertEquals(null, text.inferIndent())
+    }
+
+    @Test
+    fun `when any tabs should return tab character`() {
+        val t = '\t'
+        val text = """
+            |class Foo {
+            |${t}val bar = 1
+            |}
+        """.trimMargin()
+        Assertions.assertEquals("\t", text.inferIndent())
+    }
+
+    @Test
+    fun `blank lines should not influence the outcome`() {
+        val tab = '\t'
+        val spaces = "     "
+        val text = """
+            |type::{
+            |
+            |  name: positive_int,
+            | $spaces
+            |  type: int,
+            |$tab$tab$tab
+            |  valid_values: range::[1, max],
+            |}
+        """.trimMargin()
+        Assertions.assertEquals("  ", text.inferIndent())
+    }
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/aliased_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/aliased_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    { id: "floats.isl", type: positive_float, as: aliased_positive_float },
+    { id: "floats.isl", type: positive_int, as: aliased_positive_int },
+    { id: "floats.isl", type: negative_int, as: aliased_negative_int },
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    aliased_positive_int,
+    aliased_negative_int,
+    aliased_positive_float
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/export.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/export.isl
@@ -1,0 +1,11 @@
+$ion_schema_1_0
+schema_header::{
+  imports: [
+    { id: "floats.isl" },
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/floats.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/floats.isl
@@ -1,0 +1,30 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  // In the "unfixed" version, this file transitively exports positive_int and negative_int
+  imports: [
+    { id: "ints.isl" }
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: positive_float,
+  type: float,
+  valid_values: [range::[exclusive::0, max], +inf],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_float,
+  type: float,
+  valid_values: [range::[min, exclusive::0], -inf],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/inline_imports.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/inline_imports.isl
@@ -1,0 +1,23 @@
+$ion_schema_1_0
+
+schema_header:: {
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  // A comment that should be preserved!
+  name: foo,
+  // Another comment that should be preserved!
+  open_content: "Open content should be preserved!",
+  any_of: [
+    nullable::{ id: "floats.isl", type: positive_int },
+    { id: "floats.isl", type: negative_int },
+    { id: "floats.isl", type: positive_float },
+  ],
+}
+
+schema_footer::{
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/ints.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/ints.isl
@@ -1,0 +1,17 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_int,
+  type: int,
+  valid_values: range::[min, -1],
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/type_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/type_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    { id: "floats.isl", type: negative_float },
+    { id: "floats.isl", type: positive_int },
+    { id: "floats.isl", type: negative_int },
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    negative_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/input/wildcard_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/input/wildcard_import.isl
@@ -1,0 +1,23 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [ { id: "floats.isl" } ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    positive_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/aliased_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/aliased_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:positive_float,as:aliased_positive_float},
+    {id:"ints.isl",type:negative_int,as:aliased_negative_int},
+    {id:"ints.isl",type:positive_int,as:aliased_positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    aliased_positive_int,
+    aliased_negative_int,
+    aliased_positive_float
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/export.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/export.isl
@@ -1,0 +1,21 @@
+$ion_schema_1_0
+
+// Schema 'export.isl'
+// 
+// The purpose of this schema is to decouple consumers of the schema from the
+// implementation details (ie. specific locations) of each type that it provides,
+// and to indicate to consumers, which types they SHOULD use. Consumers of this
+// type CAN bypass this schema and import other types directly, but they SHOULD NOT
+// unless directed to do so by the owner(s)/author(s) of this schema.
+//
+// The type
+//     type::{name:foobar,type:{id:"bar.isl",type:foo}}
+// is analogous to
+//   [Javascript]: export { foo as foobar } from 'bar.isl'
+//         [Rust]: pub use bar::foo as foobar;
+
+
+type::{name:negative_float,type:{id:"floats.isl",type:negative_float}}
+type::{name:negative_int,type:{id:"ints.isl",type:negative_int}}
+type::{name:positive_float,type:{id:"floats.isl",type:positive_float}}
+type::{name:positive_int,type:{id:"ints.isl",type:positive_int}}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/floats.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/floats.isl
@@ -1,0 +1,28 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  // In the "unfixed" version, this file transitively exports positive_int and negative_int
+  imports: [],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: positive_float,
+  type: float,
+  valid_values: [range::[exclusive::0, max], +inf],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_float,
+  type: float,
+  valid_values: [range::[min, exclusive::0], -inf],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/inline_imports.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/inline_imports.isl
@@ -1,0 +1,23 @@
+$ion_schema_1_0
+
+schema_header:: {
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  // A comment that should be preserved!
+  name: foo,
+  // Another comment that should be preserved!
+  open_content: "Open content should be preserved!",
+  any_of: [
+    nullable::{id:"ints.isl",type:positive_int},
+    {id:"ints.isl",type:negative_int},
+    { id: "floats.isl", type: positive_float },
+  ],
+}
+
+schema_footer::{
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/ints.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/ints.isl
@@ -1,0 +1,17 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_int,
+  type: int,
+  valid_values: range::[min, -1],
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/type_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/type_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:negative_float},
+    {id:"ints.isl",type:negative_int},
+    {id:"ints.isl",type:positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    negative_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/wildcard_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-KeepWildcards/wildcard_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl"},
+    {id:"ints.isl",type:negative_int},
+    {id:"ints.isl",type:positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    positive_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/aliased_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/aliased_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:positive_float,as:aliased_positive_float},
+    {id:"ints.isl",type:negative_int,as:aliased_negative_int},
+    {id:"ints.isl",type:positive_int,as:aliased_positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    aliased_positive_int,
+    aliased_negative_int,
+    aliased_positive_float
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/export.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/export.isl
@@ -1,0 +1,21 @@
+$ion_schema_1_0
+
+// Schema 'export.isl'
+// 
+// The purpose of this schema is to decouple consumers of the schema from the
+// implementation details (ie. specific locations) of each type that it provides,
+// and to indicate to consumers, which types they SHOULD use. Consumers of this
+// type CAN bypass this schema and import other types directly, but they SHOULD NOT
+// unless directed to do so by the owner(s)/author(s) of this schema.
+//
+// The type
+//     type::{name:foobar,type:{id:"bar.isl",type:foo}}
+// is analogous to
+//   [Javascript]: export { foo as foobar } from 'bar.isl'
+//         [Rust]: pub use bar::foo as foobar;
+
+
+type::{name:negative_float,type:{id:"floats.isl",type:negative_float}}
+type::{name:negative_int,type:{id:"ints.isl",type:negative_int}}
+type::{name:positive_float,type:{id:"floats.isl",type:positive_float}}
+type::{name:positive_int,type:{id:"ints.isl",type:positive_int}}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/floats.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/floats.isl
@@ -1,0 +1,28 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  // In the "unfixed" version, this file transitively exports positive_int and negative_int
+  imports: [],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: positive_float,
+  type: float,
+  valid_values: [range::[exclusive::0, max], +inf],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_float,
+  type: float,
+  valid_values: [range::[min, exclusive::0], -inf],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/inline_imports.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/inline_imports.isl
@@ -1,0 +1,23 @@
+$ion_schema_1_0
+
+schema_header:: {
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  // A comment that should be preserved!
+  name: foo,
+  // Another comment that should be preserved!
+  open_content: "Open content should be preserved!",
+  any_of: [
+    nullable::{id:"ints.isl",type:positive_int},
+    {id:"ints.isl",type:negative_int},
+    { id: "floats.isl", type: positive_float },
+  ],
+}
+
+schema_footer::{
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/ints.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/ints.isl
@@ -1,0 +1,17 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_int,
+  type: int,
+  valid_values: range::[min, -1],
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/type_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/type_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:negative_float},
+    {id:"ints.isl",type:negative_int},
+    {id:"ints.isl",type:positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    negative_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/wildcard_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-NoWildcards/wildcard_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:positive_float},
+    {id:"ints.isl",type:negative_int},
+    {id:"ints.isl",type:positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    positive_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/aliased_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/aliased_import.isl
@@ -1,0 +1,27 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl",type:positive_float,as:aliased_positive_float},
+    {id:"ints.isl",type:negative_int,as:aliased_negative_int},
+    {id:"ints.isl",type:positive_int,as:aliased_positive_int},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    aliased_positive_int,
+    aliased_negative_int,
+    aliased_positive_float
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/export.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/export.isl
@@ -1,0 +1,21 @@
+$ion_schema_1_0
+
+// Schema 'export.isl'
+// 
+// The purpose of this schema is to decouple consumers of the schema from the
+// implementation details (ie. specific locations) of each type that it provides,
+// and to indicate to consumers, which types they SHOULD use. Consumers of this
+// type CAN bypass this schema and import other types directly, but they SHOULD NOT
+// unless directed to do so by the owner(s)/author(s) of this schema.
+//
+// The type
+//     type::{name:foobar,type:{id:"bar.isl",type:foo}}
+// is analogous to
+//   [Javascript]: export { foo as foobar } from 'bar.isl'
+//         [Rust]: pub use bar::foo as foobar;
+
+
+type::{name:negative_float,type:{id:"floats.isl",type:negative_float}}
+type::{name:negative_int,type:{id:"ints.isl",type:negative_int}}
+type::{name:positive_float,type:{id:"floats.isl",type:positive_float}}
+type::{name:positive_int,type:{id:"ints.isl",type:positive_int}}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/floats.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/floats.isl
@@ -1,0 +1,28 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  // In the "unfixed" version, this file transitively exports positive_int and negative_int
+  imports: [],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: positive_float,
+  type: float,
+  valid_values: [range::[exclusive::0, max], +inf],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_float,
+  type: float,
+  valid_values: [range::[min, exclusive::0], -inf],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/inline_imports.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/inline_imports.isl
@@ -1,0 +1,23 @@
+$ion_schema_1_0
+
+schema_header:: {
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  // A comment that should be preserved!
+  name: foo,
+  // Another comment that should be preserved!
+  open_content: "Open content should be preserved!",
+  any_of: [
+    nullable::{id:"ints.isl",type:positive_int},
+    {id:"ints.isl",type:negative_int},
+    { id: "floats.isl", type: positive_float },
+  ],
+}
+
+schema_footer::{
+  // A comment that should be preserved!
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/ints.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/ints.isl
@@ -1,0 +1,17 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+type::{
+  name: positive_int,
+  type: int,
+  valid_values: range::[1, max],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: negative_int,
+  type: int,
+  valid_values: range::[min, -1],
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/type_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/type_import.isl
@@ -1,0 +1,26 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl"},
+    {id:"ints.isl"},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    negative_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/wildcard_import.isl
+++ b/cli/src/test/resources/FixTransitiveImportsCommand/output-PreferWildcards/wildcard_import.isl
@@ -1,0 +1,26 @@
+$ion_schema_1_0
+
+"Open content should be preserved!"
+
+schema_header::{
+  // A comment that should be preserved!
+  imports: [
+    {id:"floats.isl"},
+    {id:"ints.isl"},
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+type::{
+  name: Foo,
+  any_of: [
+    positive_int,
+    positive_float,
+    negative_int,
+  ],
+  open_content: "Open content should be preserved!",
+}
+
+schema_footer::{
+  open_content: "Open content should be preserved!",
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/Type.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/Type.kt
@@ -31,6 +31,14 @@ interface Type {
     val name: String
 
     /**
+     * The id of the [Schema] in which this [Type] was defined. Will be `null` if the schema has no id (i.e. it was
+     * created with [IonSchemaSystem.newSchema]) or if the type does not belong to any schema (i.e. it was created with
+     * [Schema.newType] but not _added_ to a schema). Any [Type] that is loaded from any [Authority] must have a
+     * non-null [schemaId].
+     */
+    val schemaId: String?
+
+    /**
      * A read-only view of the ISL for this type.
      */
     val isl: IonValue

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInternal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeInternal.kt
@@ -26,7 +26,7 @@ internal interface TypeInternal : Type, Constraint {
     /**
      * The name of the schemaId that this type was defined in.
      */
-    val schemaId: String?
+    override val schemaId: String?
 
     @Deprecated("Only used for Ion Schema 1.0 code paths. No new usages should be introduced.")
     fun getBaseType(): TypeBuiltin


### PR DESCRIPTION
**Issue #, if available:**

Fixes #178 

**Description of changes:**

Adds a tool to the `ion-schema-kotlin` CLI for fixing transitive imports.

To use it, you just have to check out `ion-schema-kotlin` and run `./ion-schema-cli repair fix-transitive-imports ...` and include the directory where your schemas are stored.

This uses string manipulation (rather than DOM manipulation) to actually apply the changes so that comments and whitespace in the original file don't get clobbered.

This PR looks really big, but 28 of the files are test fixtures. There's a set of schema files that need to be fixed (test input), and a corrected version using each of the three import reconciliation strategies (expected outputs).

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
