### PR TITLE
Updates the model

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
@@ -13,6 +13,9 @@ package com.amazon.ionschema.model
  */
 data class ContinuousRange<T : Comparable<T>>(val start: Limit<T>, val end: Limit<T>) {
 
+    private constructor(value: Limit.Closed<T>) : this(value, value)
+    constructor(value: T) : this(Limit.Closed(value))
+
     sealed class Limit<T : Comparable<T>> {
         abstract val value: T?
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
@@ -20,6 +20,8 @@ class DiscreteIntRange private constructor(private val delegate: ContinuousRange
         )
     )
 
+    constructor(value: Int) : this(value, value)
+
     val start: Int?
         get() = (delegate.start as? ContinuousRange.Limit.Closed)?.value
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TypeArgument.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TypeArgument.kt
@@ -31,16 +31,16 @@ sealed class TypeArgument {
     /**
      * [TypeArgument] that is an anonymous type, defined inline.
      */
-    class InlineType(val typeDefinition: TypeDefinition, override val nullability: Nullability = Nullability.None) : TypeArgument()
+    data class InlineType(val typeDefinition: TypeDefinition, override val nullability: Nullability = Nullability.None) : TypeArgument()
 
     /**
      * A [TypeArgument] that references another type by [typeName] only.
      * This can refer to any types that are defined in the same schema, imported via the schema header, or any built-in types.
      */
-    class Reference(val typeName: String, override val nullability: Nullability = Nullability.None) : TypeArgument()
+    data class Reference(val typeName: String, override val nullability: Nullability = Nullability.None) : TypeArgument()
 
     /**
      * A [TypeArgument] that references a type from a different schema by [schemaId] and [typeName].
      */
-    class Import(val schemaId: String, val typeName: String, override val nullability: Nullability = Nullability.None) : TypeArgument()
+    data class Import(val schemaId: String, val typeName: String, override val nullability: Nullability = Nullability.None) : TypeArgument()
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TypeDefinition.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TypeDefinition.kt
@@ -1,10 +1,14 @@
 package com.amazon.ionschema.model
 
+import com.amazon.ionschema.util.emptyBag
+
 /**
  * Represents the common fields of all type definitions; used to compose [NamedTypeDefinition] and [TypeArgument.InlineType].
+ *
+ * Constraints are modeled as a [Set] because if there are two identical constraints, they are redundant.
  */
 @ExperimentalIonSchemaModel
-class TypeDefinition(val constraints: List<Constraint>, val openContent: OpenContentFields = emptyList()) {
+data class TypeDefinition(val constraints: Set<Constraint>, val openContent: OpenContentFields = emptyBag()) {
     override fun equals(other: Any?): Boolean {
         return other is TypeDefinition &&
             this.constraints == other.constraints &&

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/UserReservedFields.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/UserReservedFields.kt
@@ -5,7 +5,7 @@ package com.amazon.ionschema.model
  * See relevant section in [ISL 2.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#open-content).
  */
 data class UserReservedFields(
-    val type: List<String> = emptyList(),
-    val header: List<String> = emptyList(),
-    val footer: List<String> = emptyList(),
+    val type: Set<String> = emptySet(),
+    val header: Set<String> = emptySet(),
+    val footer: Set<String> = emptySet(),
 )

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ValidValue.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ValidValue.kt
@@ -12,17 +12,17 @@ sealed class ValidValue {
      * Ignoring annotations, this value is compared using Ion equivalence with data that is being validated.
      * @see [Constraint.ValidValues]
      */
-    class Value(val value: IonValue) : ValidValue() {
+    data class Value(val value: IonValue) : ValidValue() {
         init { require(value.typeAnnotations.isEmpty()) { "valid value may not be annotated" } }
     }
 
     /**
      * A range of numbers.
      */
-    class IonNumberRange(val range: NumberRange) : ValidValue()
+    data class IonNumberRange(val range: NumberRange) : ValidValue()
 
     /**
      * A range of timestamp values.
      */
-    class IonTimestampRange(val range: TimestampRange) : ValidValue()
+    data class IonTimestampRange(val range: TimestampRange) : ValidValue()
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
@@ -3,12 +3,17 @@ package com.amazon.ionschema.model
 import com.amazon.ion.IonNumber
 import com.amazon.ion.IonValue
 import com.amazon.ion.Timestamp
+import com.amazon.ionschema.util.Bag
 import java.math.BigDecimal
 
 /**
  * Convenience alias for a collections of open content fields in schema headers, footers, and type definitions.
+ * It is modeled as a [Bag] rather than a [List] because ordering is not guaranteed for structs, and we want to be able to
+ * compare two collections of open content fields for equality. It is modeled as a [Bag] rather than a [Set] because we
+ * don't know if a repeated field name and value has any meaning to the author of the schema, so we can't safely
+ * deduplicate them as we can with constraints.
  */
-typealias OpenContentFields = List<Pair<String, IonValue>>
+typealias OpenContentFields = Bag<Pair<String, IonValue>>
 
 /**
  * Convenience alias for a list of [TypeArgument].

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/util.kt
@@ -1,0 +1,17 @@
+package com.amazon.ionschema.model
+
+/**
+ * Convenience function to easily negate a constraint.
+ */
+@ExperimentalIonSchemaModel
+internal fun not(c: Constraint): Constraint {
+    return Constraint.Not(TypeArgument.InlineType(TypeDefinition(setOf(c))))
+}
+
+/**
+ * Convenience function for creating an inline type argument from a list of constraints.
+ */
+@ExperimentalIonSchemaModel
+internal fun inlineType(constraints: Set<Constraint>): TypeArgument.InlineType {
+    return TypeArgument.InlineType(TypeDefinition(constraints))
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/Bag.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/Bag.kt
@@ -1,0 +1,17 @@
+package com.amazon.ionschema.util
+
+/**
+ * A Bag (also known as a Multiset) is an unordered collection that allows duplicate elements.
+ */
+class Bag<out E>(elements: List<E>) : Collection<E> by elements {
+    constructor() : this(emptyList())
+
+    override fun equals(other: Any?): Boolean {
+        if (other === this) return true
+        if (other !is Bag<*>) return false
+        if (size != other.size) return false
+        return this.groupingBy { it }.eachCount() == other.groupingBy { it }.eachCount()
+    }
+
+    override fun hashCode(): Int = this.sumBy { it.hashCode() }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/bags.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/bags.kt
@@ -1,0 +1,18 @@
+package com.amazon.ionschema.util
+
+private val EMPTY_BAG: Bag<Nothing> = Bag(emptyList())
+
+/**
+ * Returns an empty read-only bag.
+ */
+fun <E> emptyBag(): Bag<E> = EMPTY_BAG
+
+/**
+ * Returns a new read-only bag of given elements.
+ */
+fun <E> bagOf(vararg values: E): Bag<E> = if (values.isEmpty()) emptyBag() else Bag(values.toList())
+
+/**
+ * Returns a [Bag] containing all elements.
+ */
+fun <E> Iterable<E>.toBag(): Bag<E> = Bag(this.toList())

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/model/SchemaDocumentTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/model/SchemaDocumentTest.kt
@@ -17,7 +17,7 @@ class SchemaDocumentTest {
 
     @Test
     fun `test get header when no header present`() {
-        val schema = SchemaDocument("schema.isl", listOf())
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf())
         assertNull(schema.header)
     }
 
@@ -25,13 +25,13 @@ class SchemaDocumentTest {
     fun `test get header when header present`() {
         val header = Item.Header()
         val footer = Item.Footer()
-        val schema = SchemaDocument("schema.isl", listOf(header, footer))
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(header, footer))
         assertSame(header, schema.header)
     }
 
     @Test
     fun `test get footer when no footer present`() {
-        val schema = SchemaDocument("schema.isl", listOf())
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf())
         assertNull(schema.footer)
     }
 
@@ -39,13 +39,13 @@ class SchemaDocumentTest {
     fun `test get footer when footer present`() {
         val header = Item.Header()
         val footer = Item.Footer()
-        val schema = SchemaDocument("schema.isl", listOf(header, footer))
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(header, footer))
         assertSame(footer, schema.footer)
     }
 
     @Test
     fun `test get declaredTypes when no types present`() {
-        val schema = SchemaDocument("schema.isl", listOf())
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf())
         assertTrue(schema.declaredTypes.isEmpty())
     }
 
@@ -54,64 +54,25 @@ class SchemaDocumentTest {
         val type0 = NamedTypeDefinition(
             "type0",
             TypeDefinition(
-                constraints = listOf(),
+                constraints = setOf(),
             )
         )
         val type1 = NamedTypeDefinition(
             "type1",
             TypeDefinition(
-                constraints = listOf(),
+                constraints = setOf(),
             )
         )
-        val schema = SchemaDocument("schema.isl", listOf(Item.Type(type0), Item.Type(type1)))
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(Item.Type(type0), Item.Type(type1)))
         assertEquals(2, schema.declaredTypes.size)
-        assertSame(type0, schema.declaredTypes[0])
-        assertSame(type1, schema.declaredTypes[1])
+        assertSame(type0, schema.declaredTypes["type0"])
+        assertSame(type1, schema.declaredTypes["type1"])
     }
 
     @Test
-    fun `test get ion schema version when version marker is present`() {
-        val schema = SchemaDocument(
-            "schema.isl",
-            listOf(
-                Item.OpenContent(ION.newNull()),
-                Item.VersionMarker(IonSchemaVersion.v2_0)
-            )
-        )
+    fun `test get ion schema version`() {
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf())
         assertEquals(IonSchemaVersion.v2_0, schema.ionSchemaVersion)
-    }
-
-    @Test
-    fun `test get ion schema version when header is before any version marker is present`() {
-        val schema = SchemaDocument(
-            "schema.isl",
-            listOf(
-                Item.Header(),
-                Item.VersionMarker(IonSchemaVersion.v2_0),
-                Item.Footer(),
-            )
-        )
-        // Should be ISL 1.0 since header was before version marker
-        assertEquals(IonSchemaVersion.v1_0, schema.ionSchemaVersion)
-    }
-
-    @Test
-    fun `test get ion schema version when type is before any version marker is present`() {
-        val type0 = NamedTypeDefinition(
-            "type0",
-            TypeDefinition(
-                constraints = listOf(),
-            )
-        )
-        val schema = SchemaDocument(
-            "schema.isl",
-            listOf(
-                Item.Type(type0),
-                Item.VersionMarker(IonSchemaVersion.v2_0),
-            )
-        )
-        // Should be ISL 1.0 since type was before version marker
-        assertEquals(IonSchemaVersion.v1_0, schema.ionSchemaVersion)
     }
 
     @Test
@@ -119,18 +80,17 @@ class SchemaDocumentTest {
         val type0 = NamedTypeDefinition(
             "type0",
             TypeDefinition(
-                constraints = listOf(),
+                constraints = setOf(),
             )
         )
         val type1 = NamedTypeDefinition(
             "type1",
             TypeDefinition(
-                constraints = listOf(),
+                constraints = setOf(),
             )
         )
         val schemaItems = listOf(
             Item.OpenContent(ION.newInt(1)),
-            Item.VersionMarker(IonSchemaVersion.v2_0),
             Item.OpenContent(ION.newInt(2)),
             Item.Header(),
             Item.OpenContent(ION.newInt(3)),
@@ -141,7 +101,7 @@ class SchemaDocumentTest {
             Item.Footer(),
             Item.OpenContent(ION.newInt(6)),
         )
-        val schema = SchemaDocument("schema.isl", schemaItems)
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, schemaItems)
         assertIterableEquals(schemaItems, schema.items)
     }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/util/BagTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/util/BagTest.kt
@@ -1,0 +1,63 @@
+package com.amazon.ionschema.util
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class BagTest {
+
+    @Test
+    fun `A Bag should not be equal to any other type of collection`() {
+        val bag = bagOf(1, 2, 3)
+        val set = setOf(1, 2, 3, 4)
+        assertNotEquals(bag, set)
+    }
+
+    @Test
+    fun `Bags with different content should not be equal`() {
+        val bag1 = bagOf(1, 2, 3)
+        val bag2 = bagOf(1, 2, 3, 4)
+        assertNotEquals(bag1, bag2)
+    }
+
+    @Test
+    fun `Bags with different quantities of the same content should not be equal`() {
+        val bag1 = bagOf(1, 2, 3)
+        val bag2 = bagOf(1, 1, 2, 2, 3, 3)
+        assertNotEquals(bag1, bag2)
+    }
+
+    @Test
+    fun `Bags with the same content in supposedly different order should be equal`() {
+        val bag1 = bagOf(1, 2, 3)
+        val bag2 = bagOf(3, 2, 1)
+        assertEquals(bag1, bag2)
+    }
+
+    @Test
+    fun `empty Bags should be equal`() {
+        val bag1 = Bag<Nothing>()
+        val bag2 = Bag<Nothing>()
+        assertEquals(bag1, bag2)
+    }
+
+    @Test
+    fun `equal Bags should have the equal hashcodes`() {
+        assertEquals(Bag<Nothing>().hashCode(), Bag<Nothing>().hashCode())
+        assertEquals(bagOf(1).hashCode(), bagOf(1).hashCode())
+        assertEquals(bagOf(1, 2, 3).hashCode(), bagOf(3, 2, 1).hashCode())
+    }
+
+    @Test
+    fun `emptyBag() should return a singleton object`() {
+        val bag1 = emptyBag<String>()
+        val bag2 = emptyBag<Nothing>()
+        assertSame(bag1, bag2)
+    }
+
+    @Test
+    fun `bagOf() with no elements should return the singleton emptyBag object`() {
+        assertSame(emptyBag<Nothing>(), bagOf<Nothing>())
+    }
+}


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

As I was working on the reader implementation, I ran into some issues with the model that required some changes.

Here's what's included:
- Several classes are changed to `data` classes so that we get an automatically created implementation of `equals` and `hashcode`.
- In `TypeDefinition`, the `constraints` are changed from a `List` to a `Set`. This is because the order does not matter for equality, and if two constraints are equal they are redundant, so we don't need to have both instances of the same thing in the set.
- Adds a `Bag` (aka Multiset) data type
- In `TypeDefinition`, the `openContent` is changed from a `List` to a `Bag`. Again, the order does not matter for equality, but we cannot use a`Set` in this case because duplicate open content fields might not be redundant.
- `AnnotationsV2` is given a factory method that is similar to the simplified syntax.
- Ranges are given constructors that accept a single value as a convenience for constructing a range in situations like `codepoint_length: 5`.
- In `SchemaDocument`, the ISL Version is moved from being a `SchemaDocument.Item` to being its own field in `SchemaDocument`. This makes it impossible to construct a `SchemaDocument` without an ISL version.
- In `SchemaDocument`, the `declaredTypes` are now a `Map` instead of a `List<Pair<String, NamedTypeDefinition>>`. This is because getting a type by name should not be an `O(n)` operation.
- `UserReservedFields` properties are changed from a `List` to a `Set` so that we can have an `O(1)` check for membership.

*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
