### PR TITLE
Adds readers for field_names, ieee754_float, and regex

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
@@ -83,6 +83,17 @@ internal inline fun <T : Any> Collection<T>.islRequireZeroOrOneElements(lazyMess
 }
 
 /**
+ * Validates that this [Collection] has one or more element(s).
+ *
+ * @throws InvalidSchemaException if this [Collection] does not meet the above condition.
+ * @return [this]
+ */
+internal inline fun <reified T : Any, reified C : Collection<T>> Collection<T>.islRequireNotEmpty(containerDescription: String,): C {
+    islRequire(this.isNotEmpty()) { "$containerDescription must not be empty: $this" }
+    return this as C
+}
+
+/**
  * Validates that all elements of an [Iterable] are of Ion type [T].
  * If [allowAnnotations] is false, validates that all elements have no annotations.
  * If [allowIonNulls] is false, validates that all elements are not an Ion null value.
@@ -211,4 +222,18 @@ internal fun IonStruct.islRequireOnlyExpectedFieldNames(
     } else {
         return this
     }
+}
+
+/**
+ * Validates that a value has no unexpected annotations, and that there are no duplicated annotations.
+ * @throws InvalidSchemaException if this [value] contains any annotations not in [legalAnnotations]
+ *      or any annotations that are repeated.
+ * @return the annotations of [value]
+ */
+internal inline fun islRequireNoIllegalAnnotations(value: IonValue, vararg legalAnnotations: String, lazyMessage: () -> Any): List<String> {
+    if (legalAnnotations.isEmpty()) islRequire(value.typeAnnotations.isEmpty(), lazyMessage)
+    val distinctAnnotations = value.typeAnnotations.distinct()
+    islRequire(distinctAnnotations.all { it in legalAnnotations }, lazyMessage)
+    islRequire(distinctAnnotations.size == value.typeAnnotations.size, lazyMessage)
+    return distinctAnnotations
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ConstraintReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ConstraintReader.kt
@@ -13,10 +13,14 @@ import com.amazon.ionschema.reader.internal.ReaderContext
 internal interface ConstraintReader {
 
     /**
-     * Contract—return null if and only if:
-     * - this ConstraintReader implementation does not handle the given field name _OR_
-     * - this ConstraintReader implementation does handle the given field name, but the value was not valid in some
-     *   way AND at least one error has been added to the context.
+     * Returns true if this constraint reader can read the given constraint.
      */
-    fun readConstraint(context: ReaderContext, constraintField: IonValue): Constraint?
+    fun canRead(fieldName: String): Boolean
+
+    /**
+     * Returns a [Constraint] instance for the given field.
+     * Should only be called after checking whether the constraint is supported by calling [canRead].
+     * Must throw [IllegalStateException] if called for an unsupported field name.
+     */
+    fun readConstraint(context: ReaderContext, field: IonValue): Constraint
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReader.kt
@@ -1,0 +1,31 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+/**
+ * Reads the `element` constraint for ISL 2.0 and higher
+ */
+@ExperimentalIonSchemaModel
+internal class FieldNamesReader(private val typeReader: TypeReader) : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "field_names"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireNoIllegalAnnotations(field, "distinct", "\$null_or") {
+            invalidConstraint(
+                field,
+                "type argument may only be annotated with 'distinct' or '\$null_or'"
+            )
+        }
+        val typeArg = typeReader.readTypeArg(context, field, checkAnnotations = false)
+
+        return Constraint.FieldNames(typeArg, distinct = field.hasTypeAnnotation("distinct"))
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReader.kt
@@ -9,7 +9,7 @@ import com.amazon.ionschema.reader.internal.TypeReader
 import com.amazon.ionschema.reader.internal.invalidConstraint
 
 /**
- * Reads the `element` constraint for ISL 2.0 and higher
+ * Reads the `field_names` constraint for ISL 2.0 and higher
  */
 @ExperimentalIonSchemaModel
 internal class FieldNamesReader(private val typeReader: TypeReader) : ConstraintReader {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/Ieee754FloatReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/Ieee754FloatReader.kt
@@ -1,0 +1,30 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.Ieee754InterchangeFormat
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class Ieee754FloatReader : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "ieee754_float"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireNoIllegalAnnotations(field) { invalidConstraint(field, "must not have annotations") }
+        val format = when ((field as? IonSymbol)?.stringValue()) {
+            "binary16" -> Ieee754InterchangeFormat.Binary16
+            "binary32" -> Ieee754InterchangeFormat.Binary32
+            "binary64" -> Ieee754InterchangeFormat.Binary64
+            else -> throw InvalidSchemaException(invalidConstraint(field, "must be one of 'binary16', 'binary32', 'binary64'"))
+        }
+
+        return Constraint.Ieee754Float(format)
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/RegexReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/RegexReader.kt
@@ -1,0 +1,30 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonString
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class RegexReader(private val ionSchemaVersion: IonSchemaVersion) : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "regex"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireIonTypeNotNull<IonString>(field) { invalidConstraint(field, "must be a non-null string") }
+        islRequireNoIllegalAnnotations(field, "i", "m") { invalidConstraint(field, "regex pattern may only be annotated with 'i' and 'm'") }
+
+        return Constraint.Regex(
+            field.stringValue(),
+            multiline = field.hasTypeAnnotation("m"),
+            caseInsensitive = field.hasTypeAnnotation("i"),
+            ionSchemaVersion = ionSchemaVersion
+        )
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
@@ -28,3 +28,10 @@ internal inline fun <T : Any> readCatching(context: ReaderContext, value: IonVal
 internal inline fun <T : Any> Iterable<IonValue>.readAllCatching(context: ReaderContext, crossinline block: (IonValue) -> T?): List<T> {
     return mapNotNull { readCatching(context, it) { block(it) } }
 }
+
+/**
+ * Formats a message for an invalid constraint
+ */
+internal fun invalidConstraint(value: IonValue, reason: String, constraintName: String = value.fieldName): String {
+    return "Illegal argument for '$constraintName' constraint; $reason: $value"
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldNamesReaderTest.kt
@@ -1,0 +1,108 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class FieldNamesReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'field_names'`() {
+        val reader = FieldNamesReader(mockk())
+        Assertions.assertTrue(reader.canRead("field_names"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'field_names'`() {
+        val reader = FieldNamesReader(mockk())
+        Assertions.assertFalse(reader.canRead("nield_fames"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'field_names' should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = FieldNamesReader(mockk())
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reading a valid field_names constraint should return a FieldNames instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldNamesReader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ field_names: symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.FieldNames(mockType)
+        val actual = reader.readConstraint(context, struct["field_names"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a valid field_names constraint with 'distinct' should return a FieldNames instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldNamesReader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ field_names: distinct::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.FieldNames(mockType, distinct = true)
+        val actual = reader.readConstraint(context, struct["field_names"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a valid field_names constraint with '$null_or' should return a FieldNames instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldNamesReader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ field_names: ${'$'}null_or::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.FieldNames(mockType)
+        val actual = reader.readConstraint(context, struct["field_names"])
+        kotlin.test.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a field_names constraint with any annotation other than 'distinct' or '$null_or' should throw exception`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldNamesReader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ field_names: foo::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        assertThrows<InvalidSchemaException> {
+            reader.readConstraint(context, struct["field_names"])
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/Ieee745FloatReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/Ieee745FloatReaderTest.kt
@@ -1,0 +1,84 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.Ieee754InterchangeFormat
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class Ieee745FloatReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'ieee754_float'`() {
+        val reader = Ieee754FloatReader()
+        Assertions.assertTrue(reader.canRead("ieee754_float"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'ieee754_float'`() {
+        val reader = Ieee754FloatReader()
+        Assertions.assertFalse(reader.canRead("ieee754_float_boat"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'ieee754_float' should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `read ieee754_float with unknown float format should throw exception`() {
+        val struct = ION.singleValue("""{ ieee754_float: binary1995 }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        assertThrows<InvalidSchemaException> { reader.readConstraint(context, struct["ieee754_float"]) }
+    }
+
+    @Test
+    fun `read ieee754_float with annotation should throw exception`() {
+        val struct = ION.singleValue("""{ ieee754_float: foo::binary32 }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        assertThrows<InvalidSchemaException> { reader.readConstraint(context, struct["ieee754_float"]) }
+    }
+
+    @Test
+    fun `read ieee754_float with binary16 should return ieee754_float constraint`() {
+        val struct = ION.singleValue("""{ ieee754_float: binary16 }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        val actual = reader.readConstraint(context, struct["ieee754_float"])
+        assertEquals(Constraint.Ieee754Float(Ieee754InterchangeFormat.Binary16), actual)
+    }
+
+    @Test
+    fun `read ieee754_float with binary32 should return ieee754_float constraint`() {
+        val struct = ION.singleValue("""{ ieee754_float: binary32 }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        val actual = reader.readConstraint(context, struct["ieee754_float"])
+        assertEquals(Constraint.Ieee754Float(Ieee754InterchangeFormat.Binary32), actual)
+    }
+
+    @Test
+    fun `read ieee754_float with binary64 should return ieee754_float constraint`() {
+        val struct = ION.singleValue("""{ ieee754_float: binary64 }""") as IonStruct
+        val reader = Ieee754FloatReader()
+        val context = ReaderContext()
+        val actual = reader.readConstraint(context, struct["ieee754_float"])
+        assertEquals(Constraint.Ieee754Float(Ieee754InterchangeFormat.Binary64), actual)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/RegexReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/RegexReaderTest.kt
@@ -1,0 +1,104 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class RegexReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+        val READER_1 = RegexReader(IonSchemaVersion.v1_0)
+        val READER_2 = RegexReader(IonSchemaVersion.v2_0)
+    }
+
+    @Test
+    fun `canRead should return true for 'regex'`() {
+        Assertions.assertTrue(READER_1.canRead("regex"))
+        Assertions.assertTrue(READER_2.canRead("regex"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'regex'`() {
+        Assertions.assertFalse(READER_1.canRead("xeger"))
+        Assertions.assertFalse(READER_2.canRead("xeger"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'regex' should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { READER_1.readConstraint(context, struct["foo"]) }
+        assertThrows<IllegalStateException> { READER_2.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `read regex with invalid pattern should throw exception`() {
+        val struct = ION.singleValue("""{ regex: "**{([" }""") as IonStruct
+        val context = ReaderContext()
+        assertThrows<IllegalArgumentException> { READER_1.readConstraint(context, struct["regex"]) }
+        assertThrows<IllegalArgumentException> { READER_2.readConstraint(context, struct["regex"]) }
+    }
+
+    @Test
+    fun `read regex with invalid modifiers should throw exception`() {
+        // only valid modifier annotations are 'i' and 'm'
+        val struct = ION.singleValue("""{ regex: Q::"abc" }""") as IonStruct
+        val context = ReaderContext()
+        assertThrows<InvalidSchemaException> { READER_1.readConstraint(context, struct["regex"]) }
+        assertThrows<InvalidSchemaException> { READER_2.readConstraint(context, struct["regex"]) }
+    }
+
+    @Test
+    fun `read regex with unsupported feature for ISL 1,0 should throw exception`() {
+        // character class meta-chars inside a character set are not supported until Ion Schema 2.0
+        val struct = ION.singleValue("""{ regex: "[a-f\\d]" }""") as IonStruct
+        val context = ReaderContext() // val result = READER_1.readConstraint(context, struct["regex"])
+        assertThrows<InvalidSchemaException> { READER_1.readConstraint(context, struct["regex"]) }
+    }
+
+    @Test
+    fun `read valid regex should return regex constraint for ISL 1,0`() {
+        val struct = ION.singleValue("""{ regex: "^[0-9a-f]+$" }""") as IonStruct
+        val context = ReaderContext()
+        val expected = Constraint.Regex("^[0-9a-f]+$", ionSchemaVersion = IonSchemaVersion.v1_0)
+        val actual = READER_1.readConstraint(context, struct["regex"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `read valid regex should return regex constraint for ISL 2,0`() {
+        val struct = ION.singleValue("""{ regex: "^[0-9a-f]+$" }""") as IonStruct
+        val context = ReaderContext()
+        val expected = Constraint.Regex("^[0-9a-f]+$", ionSchemaVersion = IonSchemaVersion.v2_0)
+        val actual = READER_2.readConstraint(context, struct["regex"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `read regex should correctly handle multiline modifier`() {
+        val struct = ION.singleValue("""{ regex: m::"^[0-9a-f]+$" }""") as IonStruct
+        val context = ReaderContext()
+        val expected = Constraint.Regex("^[0-9a-f]+$", multiline = true, ionSchemaVersion = IonSchemaVersion.v2_0)
+        val actual = READER_2.readConstraint(context, struct["regex"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `read regex should correctly handle case-insensitive modifier`() {
+        val struct = ION.singleValue("""{ regex: i::"^[0-9a-f]+$" }""") as IonStruct
+        val context = ReaderContext()
+        val expected = Constraint.Regex("^[0-9a-f]+$", caseInsensitive = true, ionSchemaVersion = IonSchemaVersion.v2_0)
+        val actual = READER_2.readConstraint(context, struct["regex"])
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256

**Description of changes:**

* Updates the `ConstraintReader` interface to better suit the mediator pattern.
* Adds readers for `field_names`, `ieee754_float`, and `regex`

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
