### PR TITLE
Adds readers for exponent, precision, and __length constraints

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/Preconditions.kt
@@ -237,3 +237,14 @@ internal inline fun islRequireNoIllegalAnnotations(value: IonValue, vararg legal
     islRequire(distinctAnnotations.size == value.typeAnnotations.size, lazyMessage)
     return distinctAnnotations
 }
+
+/**
+ * Validates that a value has no unexpected annotations, and that there are no duplicated annotations.
+ * @throws InvalidSchemaException if this [value] contains any annotations not in [annotations]
+ *      or any annotations that are repeated.
+ * @return the annotations of [value]
+ */
+internal inline fun islRequireExactAnnotations(value: IonValue, vararg annotations: String, lazyMessage: () -> Any): List<String> {
+    islRequire(annotations contentDeepEquals value.typeAnnotations, lazyMessage)
+    return value.typeAnnotations.toList()
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -12,7 +12,10 @@ import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.reader.internal.constraints.ExponentReader
 import com.amazon.ionschema.reader.internal.constraints.Ieee754FloatReader
+import com.amazon.ionschema.reader.internal.constraints.LengthConstraintsReader
+import com.amazon.ionschema.reader.internal.constraints.PrecisionReader
 import com.amazon.ionschema.reader.internal.constraints.RegexReader
 import com.amazon.ionschema.util.toBag
 
@@ -20,7 +23,10 @@ import com.amazon.ionschema.util.toBag
 internal class TypeReaderV2_0 : TypeReader {
 
     private val constraintReaders = listOf(
+        ExponentReader(),
         Ieee754FloatReader(),
+        LengthConstraintsReader(),
+        PrecisionReader(),
         RegexReader(IonSchemaVersion.v2_0),
     )
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ExponentReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ExponentReader.kt
@@ -1,0 +1,17 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.toDiscreteIntRange
+
+@ExperimentalIonSchemaModel
+internal class ExponentReader : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "exponent"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+        return Constraint.Exponent(field.toDiscreteIntRange())
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/LengthConstraintsReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/LengthConstraintsReader.kt
@@ -1,0 +1,30 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.toDiscreteIntRange
+
+@ExperimentalIonSchemaModel
+internal class LengthConstraintsReader : ConstraintReader {
+    companion object {
+        private val CONSTRAINT_NAMES = setOf("byte_length", "codepoint_length", "container_length", "utf8_byte_length")
+    }
+
+    override fun canRead(fieldName: String): Boolean = fieldName in CONSTRAINT_NAMES
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        val range = field.toDiscreteIntRange()
+
+        return when (field.fieldName) {
+            "byte_length" -> Constraint.ByteLength(range)
+            "codepoint_length" -> Constraint.CodepointLength(range)
+            "container_length" -> Constraint.ContainerLength(range)
+            "utf8_byte_length" -> Constraint.Utf8ByteLength(range)
+            else -> TODO("Unreachable!")
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/PrecisionReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/PrecisionReader.kt
@@ -1,0 +1,17 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.toDiscreteIntRange
+
+@ExperimentalIonSchemaModel
+internal class PrecisionReader : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "precision"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+        return Constraint.Precision(field.toDiscreteIntRange())
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
@@ -1,0 +1,66 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonInt
+import com.amazon.ion.IonList
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireExactAnnotations
+import com.amazon.ionschema.internal.util.islRequireIonNotNull
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.DiscreteIntRange
+
+/**
+ * Converts an [IonValue] to a [DiscreteIntRange]
+ */
+internal fun IonValue.toDiscreteIntRange(): DiscreteIntRange {
+    return when (this) {
+        is IonList -> {
+            islRequire(size == 2) { "Invalid range; size of list must be 2:  $this" }
+            islRequireExactAnnotations(this, "range") { "Invalid range; missing 'range' annotation:  $this" }
+            val lower = readDiscreteIntRangeBoundary(BoundaryPosition.Lower)
+            val upper = readDiscreteIntRangeBoundary(BoundaryPosition.Upper)
+            return DiscreteIntRange(lower, upper)
+        }
+        is IonInt -> {
+            islRequireIonNotNull(this) { "Range cannot be a null value" }
+            islRequireNoIllegalAnnotations(this) { "Constraint may not be annotated" }
+            DiscreteIntRange(this.intValue(), this.intValue())
+        }
+        else -> throw InvalidSchemaException("Invalid range; not an ion list: $this")
+    }
+}
+
+/**
+ * Represents either the upper bound or the lower bound. Allows us to write functions that can be re-used for both
+ * bounds to avoid duplicated code.
+ */
+internal enum class BoundaryPosition(val idx: Int, val symbol: String, val intExclusivityAdjustment: Int) {
+    Lower(0, "min", intExclusivityAdjustment = 1),
+    Upper(1, "max", intExclusivityAdjustment = -1);
+}
+
+/**
+ * Reads and validates a single endpoint of an int range.
+ */
+private fun IonList.readDiscreteIntRangeBoundary(bp: BoundaryPosition): Int? {
+    val it = get(bp.idx) ?: throw InvalidSchemaException("Invalid range; missing $bp boundary value: $this")
+    return if (it is IonSymbol && it.stringValue() == bp.symbol) {
+        islRequireNoIllegalAnnotations(it) { "Invalid range; '${bp.symbol}' may not be exclusive: $it" }
+        null
+    } else {
+        val value = islRequireIonTypeNotNull<IonInt>(it) { "Invalid range; $bp boundary of range must be '${bp.symbol}' or a non-null int" }
+        value.intValue() + if (readBoundaryExclusivity(bp)) bp.intExclusivityAdjustment else 0
+    }
+}
+
+/**
+ * Reads and validates annotations on the endpoint of a range, returning true iff the endpoint is exclusive.
+ */
+private fun IonList.readBoundaryExclusivity(boundaryPosition: BoundaryPosition): Boolean {
+    val b = get(boundaryPosition.idx)!!
+    islRequireNoIllegalAnnotations(b, "exclusive") { "Invalid range; illegal annotation on $boundaryPosition bound: $this" }
+    return b.hasTypeAnnotation("exclusive")
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -27,22 +27,16 @@ class ReaderTests {
         "all_of",
         "annotations",
         "any_of",
-        "byte_length",
-        "codepoint_length",
-        "container_length",
         "contains",
         "element",
-        "exponent",
         "field_names", // This is implemented, but it requires type args, which are not implemented yet.
         "fields",
         "not",
         "one_of",
         "ordered_elements",
-        "precision",
         "timestamp_offset",
         "timestamp_precision",
         "type",
-        "utf8_byte_length",
         "valid_values",
     )
     val unimplementedConstraintsRegex = Regex("constraints/(${unimplementedConstraints.joinToString("|")})")

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ExponentReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ExponentReaderTest.kt
@@ -1,0 +1,90 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class ExponentReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'exponent'`() {
+        assertTrue(ExponentReader().canRead("exponent"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'exponent'`() {
+        val reader = ExponentReader()
+        Assertions.assertFalse(reader.canRead("scale"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reader should be able to read a single value`() {
+        val struct = ION.singleValue("""{ exponent: 3 }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        val expected = Constraint.Exponent(DiscreteIntRange(3))
+        val result = reader.readConstraint(context, struct["exponent"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range`() {
+        val struct = ION.singleValue("""{ exponent: range::[1, 4] }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        val expected = Constraint.Exponent(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["exponent"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded upper endpoint`() {
+        val struct = ION.singleValue("""{ exponent: range::[1, max] }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        val expected = Constraint.Exponent(DiscreteIntRange(1, null))
+        val result = reader.readConstraint(context, struct["exponent"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded lower endpoint`() {
+        val struct = ION.singleValue("""{ exponent: range::[min, 4] }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        val expected = Constraint.Exponent(DiscreteIntRange(null, 4))
+        val result = reader.readConstraint(context, struct["exponent"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with exclusive endpoint`() {
+        val struct = ION.singleValue("""{ exponent: range::[1, exclusive::5] }""") as IonStruct
+        val reader = ExponentReader()
+        val context = ReaderContext()
+        val expected = Constraint.Exponent(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["exponent"])
+        assertEquals(expected, result)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LengthConstraintsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LengthConstraintsReaderTest.kt
@@ -1,0 +1,93 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class LengthConstraintsReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @ValueSource(strings = ["byte_length", "codepoint_length", "container_length", "utf8_byte_length"])
+    @ParameterizedTest(name = "canRead should return true for {0}")
+    fun `canRead should return true for supported constraints`(fieldName: String) {
+        assertTrue(LengthConstraintsReader().canRead(fieldName))
+    }
+
+    @Test
+    fun `canRead should return false for unsupported constraints`() {
+        val reader = LengthConstraintsReader()
+        Assertions.assertFalse(reader.canRead("planck_length"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reader should be able to read a single value`() {
+        val struct = ION.singleValue("""{ byte_length: 3 }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        val expected = Constraint.ByteLength(DiscreteIntRange(3))
+        val result = reader.readConstraint(context, struct["byte_length"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range`() {
+        val struct = ION.singleValue("""{ byte_length: range::[1, 4] }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        val expected = Constraint.ByteLength(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["byte_length"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded upper endpoint`() {
+        val struct = ION.singleValue("""{ codepoint_length: range::[1, max] }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        val expected = Constraint.CodepointLength(DiscreteIntRange(1, null))
+        val result = reader.readConstraint(context, struct["codepoint_length"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded lower endpoint`() {
+        val struct = ION.singleValue("""{ container_length: range::[min, 4] }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        val expected = Constraint.ContainerLength(DiscreteIntRange(null, 4))
+        val result = reader.readConstraint(context, struct["container_length"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with exclusive endpoint`() {
+        val struct = ION.singleValue("""{ utf8_byte_length: range::[1, exclusive::5] }""") as IonStruct
+        val reader = LengthConstraintsReader()
+        val context = ReaderContext()
+        val expected = Constraint.Utf8ByteLength(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["utf8_byte_length"])
+        assertEquals(expected, result)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/PrecisionReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/PrecisionReaderTest.kt
@@ -1,0 +1,90 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class PrecisionReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'precision'`() {
+        assertTrue(PrecisionReader().canRead("precision"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'precision'`() {
+        val reader = PrecisionReader()
+        Assertions.assertFalse(reader.canRead("scale"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reader should be able to read a single value`() {
+        val struct = ION.singleValue("""{ precision: 3 }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.Precision(DiscreteIntRange(3))
+        val result = reader.readConstraint(context, struct["precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range`() {
+        val struct = ION.singleValue("""{ precision: range::[1, 4] }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.Precision(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded upper endpoint`() {
+        val struct = ION.singleValue("""{ precision: range::[1, max] }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.Precision(DiscreteIntRange(1, null))
+        val result = reader.readConstraint(context, struct["precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded lower endpoint`() {
+        val struct = ION.singleValue("""{ precision: range::[min, 4] }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.Precision(DiscreteIntRange(null, 4))
+        val result = reader.readConstraint(context, struct["precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with exclusive endpoint`() {
+        val struct = ION.singleValue("""{ precision: range::[1, exclusive::5] }""") as IonStruct
+        val reader = PrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.Precision(DiscreteIntRange(1, 4))
+        val result = reader.readConstraint(context, struct["precision"])
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

* Adds readers for all of the ISL 2.0 constraints that take an int range—`byte_length`, `codepoint_length`, `container_length`, `exponent`, `precision`, and `utf8_byte_length`


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
