### PR TITLE
Adds impl of IonSchemaReaderV2_0 and ion-schema-tests for readers

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
@@ -1,0 +1,34 @@
+package com.amazon.ionschema.reader
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.reader.internal.ReadError
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReaderV2_0
+import com.amazon.ionschema.util.IonSchemaResult
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class IonSchemaReaderV2_0 : IonSchemaReader {
+    private val typeReader = TypeReaderV2_0()
+
+    override fun readSchema(document: List<IonValue>, failFast: Boolean): IonSchemaResult<SchemaDocument, List<ReadError>> {
+        TODO()
+    }
+
+    override fun readType(ion: IonValue, failFast: Boolean): IonSchemaResult<TypeDefinition, List<ReadError>> {
+        val context = ReaderContext(failFast = failFast)
+        val typeDefinition = typeReader.readOrphanedTypeDefinition(context, ion)
+        return if (context.readErrors.isEmpty()) {
+            IonSchemaResult.Ok(typeDefinition)
+        } else {
+            IonSchemaResult.Err(context.readErrors)
+        }
+    }
+
+    override fun readNamedType(ion: IonValue, failFast: Boolean): IonSchemaResult<NamedTypeDefinition, List<ReadError>> {
+        TODO()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -1,0 +1,74 @@
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.reader.internal.constraints.Ieee754FloatReader
+import com.amazon.ionschema.reader.internal.constraints.RegexReader
+import com.amazon.ionschema.util.toBag
+
+@ExperimentalIonSchemaModel
+internal class TypeReaderV2_0 : TypeReader {
+
+    private val constraintReaders = listOf(
+        Ieee754FloatReader(),
+        RegexReader(IonSchemaVersion.v2_0),
+    )
+
+    override fun readNamedTypeDefinition(context: ReaderContext, ion: IonValue): NamedTypeDefinition {
+        TODO()
+    }
+
+    override fun readTypeArg(context: ReaderContext, ion: IonValue, checkAnnotations: Boolean): TypeArgument {
+        TODO()
+    }
+
+    override fun readVariablyOccurringTypeArg(context: ReaderContext, ion: IonValue, defaultOccurs: DiscreteIntRange): VariablyOccurringTypeArgument {
+        TODO()
+    }
+
+    /**
+     * Reads a type that exists outside the context of any schema.
+     */
+    fun readOrphanedTypeDefinition(context: ReaderContext, ion: IonValue): TypeDefinition {
+        islRequireIonTypeNotNull<IonStruct>(ion) { "Type definitions must be a non-null struct; was: $ion" }
+        islRequire(!ion.containsKey("name")) { "Anonymous type definitions may not have a 'name' field" }
+        islRequire(!ion.containsKey("occurs")) { "Anonymous type definitions may not have a 'occurs' field" }
+        return privateReadTypeDefinition(context, ion)
+    }
+
+    /**
+     * Common functionality for reading named type definitions, inline types, and variably occurring type args.
+     * The fields "name" and "occurs" must be handled by the calling function.
+     */
+    private fun privateReadTypeDefinition(context: ReaderContext, type: IonStruct): TypeDefinition {
+        val constraints = mutableListOf<Constraint>()
+        val openContent = mutableListOf<Pair<String, IonValue>>()
+
+        type.readAllCatching(context) { field ->
+            val fieldName = field.fieldName
+            if (fieldName == "occurs" || fieldName == "name") {
+                // Skip 'occurs' and 'name' -- they are handled elsewhere
+            } else {
+                val readerForThisConstraint = constraintReaders.firstOrNull { it.canRead(fieldName) }
+
+                if (readerForThisConstraint != null) {
+                    constraints.add(readerForThisConstraint.readConstraint(context, field))
+                } else {
+                    // TODO: Make sure that it's a legal field name for open content
+                    openContent.add(fieldName to field)
+                }
+            }
+        }
+        return TypeDefinition(constraints.toSet(), openContent.toBag())
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -1,0 +1,162 @@
+package com.amazon.ionschema.reader
+
+import com.amazon.ion.IonBool
+import com.amazon.ion.IonList
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaTests
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.TestFactory
+import com.amazon.ionschema.asDocument
+import com.amazon.ionschema.getTextField
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import org.junit.jupiter.api.DynamicContainer
+import org.junit.jupiter.api.DynamicNode
+import org.junit.jupiter.api.DynamicTest
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.assertThrows
+import java.io.File
+import java.util.stream.Stream
+
+@ExperimentalIonSchemaModel
+class ReaderTests {
+
+    val unimplementedConstraints = listOf(
+        "all_of",
+        "annotations",
+        "any_of",
+        "byte_length",
+        "codepoint_length",
+        "container_length",
+        "contains",
+        "element",
+        "exponent",
+        "field_names", // This is implemented, but it requires type args, which are not implemented yet.
+        "fields",
+        "not",
+        "one_of",
+        "ordered_elements",
+        "precision",
+        "timestamp_offset",
+        "timestamp_precision",
+        "type",
+        "utf8_byte_length",
+        "valid_values",
+    )
+    val unimplementedConstraintsRegex = Regex("constraints/(${unimplementedConstraints.joinToString("|")})")
+
+    @Nested
+    inner class IonSchema_2_0 : TestFactory by ReaderTestsRunner(
+        version = IonSchemaVersion.v2_0,
+        reader = IonSchemaReaderV2_0(),
+        additionalFileFilter = {
+            !it.path.contains(unimplementedConstraintsRegex) &&
+                !it.path.contains("schema/") &&
+                !it.path.contains("imports/") &&
+                !it.path.contains("open_content/") &&
+                !it.path.contains("null_or.isl")
+        },
+        testNameFilter = {
+            // readNamedType() and readSchema() are not implemented yet
+            !it.contains("readNamedType") && !it.contains("readSchema")
+        }
+    )
+}
+
+@ExperimentalIonSchemaModel
+class ReaderTestsRunner(
+    val version: IonSchemaVersion,
+    val reader: IonSchemaReader,
+    additionalFileFilter: (File) -> Boolean = { true },
+    private val testNameFilter: (String) -> Boolean = { true },
+) : TestFactory {
+
+    companion object {
+        private val ION = IonSystemBuilder.standard().build()
+    }
+
+    private val fileFilter: (File) -> Boolean = { it.path.endsWith(".isl") && additionalFileFilter(it) }
+    private val baseDir = IonSchemaTests.testDirectoryFor(version)
+
+    override fun generateTests(): Iterable<DynamicNode> {
+        return baseDir.walk()
+            .filter { it.isFile }
+            .filter(fileFilter)
+            .map { generateTestCases(it) }
+            .asIterable()
+    }
+
+    private fun generateTestCases(f: File): DynamicNode {
+        val relativeFile = f.relativeTo(baseDir)
+        val dg = ION.loader.load(f)
+
+        val fileIslVersion = dg[0].takeIf { IonSchemaVersion.isVersionMarker(it) }
+            ?.let { IonSchemaVersion.fromIonSymbolOrNull(it as IonSymbol) }
+            ?.takeIf { it == IonSchemaVersion.v2_0 }
+            ?: IonSchemaVersion.v1_0
+
+        if (fileIslVersion != IonSchemaVersion.v2_0) return DynamicContainer.dynamicContainer(relativeFile.path, f.toURI(), Stream.empty())
+
+        val validSchemaCase =
+            DynamicTest.dynamicTest("[$relativeFile] readSchema should read a valid schema document") {
+                reader.readSchemaOrThrow(dg)
+            }
+
+        val dynamicNodeTestCases = dg.mapNotNull { ion ->
+            // The reader is a little more sophisticated than ISL for ISL, but it cannot detect problems with
+            // duplicate type names or imports.
+            if (ion !is IonStruct || !ion.islForIslCanValidate()) return@mapNotNull null
+
+            when {
+                ion.hasTypeAnnotation("type") -> {
+                    val displayName = "[$relativeFile] readNamedType '${ion.getTextField("name")}'"
+                    DynamicTest.dynamicTest(displayName) { reader.readNamedTypeOrThrow(ion) }
+                }
+                IonSchemaTests.isInvalidTypesTestCase(ion) -> {
+                    val baseDescription = ion.getTextField("description")
+                    val cases = (ion["invalid_types"] as IonList).mapIndexed { i, invalidType ->
+                        val displayName = "[$relativeFile] $baseDescription [$i]"
+                        DynamicTest.dynamicTest(displayName) {
+                            assertThrows<InvalidSchemaException> { reader.readTypeOrThrow(invalidType) }
+                        }
+                    }
+                    DynamicContainer.dynamicContainer("[$relativeFile] $baseDescription", cases)
+                }
+
+                IonSchemaTests.isInvalidSchemasTestCase(ion) -> {
+                    createSchemasTestCases("$relativeFile", ion, expectValid = false)
+                }
+                IonSchemaTests.isValidSchemasTestCase(ion) -> {
+                    createSchemasTestCases("$relativeFile", ion, expectValid = true)
+                }
+                else -> null
+            }
+        }
+
+        return DynamicContainer.dynamicContainer(
+            relativeFile.path,
+            f.toURI(),
+            (dynamicNodeTestCases + validSchemaCase).stream().filter { testNameFilter(it.displayName) }
+        )
+    }
+
+    private fun createSchemasTestCases(schemaId: String, ion: IonStruct, expectValid: Boolean): DynamicNode {
+        val baseDescription = ion.getTextField("description")
+        val schemasField = if (expectValid) "valid_schemas" else "invalid_schemas"
+        val cases = (ion[schemasField] as IonList).mapIndexed { i, it ->
+            DynamicTest.dynamicTest("[$schemaId] $baseDescription [$i]") {
+                if (expectValid)
+                    reader.readSchemaOrThrow(it.asDocument()) // Asserts nothing is thrown
+                else
+                    assertThrows<InvalidSchemaException> { reader.readSchemaOrThrow(it.asDocument()) }
+            }
+        }
+        return DynamicContainer.dynamicContainer("[$schemaId] $baseDescription", cases)
+    }
+
+    private fun IonStruct.islForIslCanValidate(): Boolean {
+        return (this["isl_for_isl_can_validate"] as? IonBool)?.booleanValue() ?: true
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

Adds initial, partial implementation of `TypeReaderV2_0` and `IonSchemaReaderV2_0`, but more importantly, it sets up a test runner that can leverage `ion-schema-tests` for the reader implementation.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
