### PR TITLE
Adds readers for element and logic constraints

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -1,10 +1,15 @@
 package com.amazon.ionschema.reader.internal
 
 import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.getIslRequiredField
 import com.amazon.ionschema.internal.util.islRequire
 import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireOnlyExpectedFieldNames
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.DiscreteIntRange
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
@@ -12,9 +17,12 @@ import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.reader.internal.constraints.ElementV2Reader
 import com.amazon.ionschema.reader.internal.constraints.ExponentReader
+import com.amazon.ionschema.reader.internal.constraints.FieldNamesReader
 import com.amazon.ionschema.reader.internal.constraints.Ieee754FloatReader
 import com.amazon.ionschema.reader.internal.constraints.LengthConstraintsReader
+import com.amazon.ionschema.reader.internal.constraints.LogicConstraintsReader
 import com.amazon.ionschema.reader.internal.constraints.PrecisionReader
 import com.amazon.ionschema.reader.internal.constraints.RegexReader
 import com.amazon.ionschema.util.toBag
@@ -23,9 +31,12 @@ import com.amazon.ionschema.util.toBag
 internal class TypeReaderV2_0 : TypeReader {
 
     private val constraintReaders = listOf(
+        ElementV2Reader(this),
         ExponentReader(),
+        FieldNamesReader(this),
         Ieee754FloatReader(),
         LengthConstraintsReader(),
+        LogicConstraintsReader(this),
         PrecisionReader(),
         RegexReader(IonSchemaVersion.v2_0),
     )
@@ -35,7 +46,31 @@ internal class TypeReaderV2_0 : TypeReader {
     }
 
     override fun readTypeArg(context: ReaderContext, ion: IonValue, checkAnnotations: Boolean): TypeArgument {
-        TODO()
+        if (checkAnnotations) islRequire(ion.typeAnnotations.isEmpty() || ion.typeAnnotations.single() == "\$null_or") {
+            "Invalid constraint; illegal annotation on type argument: $ion"
+        }
+        val nullability = if (ion.hasTypeAnnotation("\$null_or")) TypeArgument.Nullability.OrNull else TypeArgument.Nullability.None
+        return when {
+            ion is IonStruct && ion.containsKey("id") -> {
+                ion.islRequireOnlyExpectedFieldNames(listOf("id", "type"))
+                TypeArgument.Import(
+                    schemaId = ion.getIslRequiredField<IonText>("id").stringValue(),
+                    typeName = ion.getIslRequiredField<IonSymbol>("type").stringValue(),
+                    nullability = nullability,
+                ).also { context.unresolvedReferences.add(it) }
+            }
+            ion is IonStruct -> {
+                islRequire(!ion.containsKey("name")) { "Inline type definitions may not have a 'name' field" }
+                islRequire(!ion.containsKey("occurs")) { "Inline type definitions may not have a 'occurs' field" }
+
+                TypeArgument.InlineType(
+                    typeDefinition = privateReadTypeDefinition(context, ion),
+                    nullability = nullability,
+                )
+            }
+            ion is IonSymbol -> TypeArgument.Reference(ion.stringValue(), nullability).also { context.unresolvedReferences.add(it) }
+            else -> throw InvalidSchemaException("Invalid constraint; not a valid type argument: $ion")
+        }
     }
 
     override fun readVariablyOccurringTypeArg(context: ReaderContext, ion: IonValue, defaultOccurs: DiscreteIntRange): VariablyOccurringTypeArgument {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ElementV2Reader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ElementV2Reader.kt
@@ -1,0 +1,31 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+/**
+ * Reads the `element` constraint for ISL 2.0 and higher
+ */
+@ExperimentalIonSchemaModel
+internal class ElementV2Reader(private val typeReader: TypeReader) : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "element"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireNoIllegalAnnotations(field, "distinct", "\$null_or") {
+            invalidConstraint(
+                field,
+                "type argument may only be annotated with 'distinct' or '\$null_or'"
+            )
+        }
+
+        val typeArg = typeReader.readTypeArg(context, field, checkAnnotations = false)
+        return Constraint.Element(typeArg, distinct = field.hasTypeAnnotation("distinct"))
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReader.kt
@@ -1,0 +1,29 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+
+@ExperimentalIonSchemaModel
+internal class LogicConstraintsReader(private val typeReader: TypeReader) : ConstraintReader {
+    companion object {
+        private val CONSTRAINT_NAMES = setOf("all_of", "any_of", "not", "one_of", "type")
+    }
+
+    override fun canRead(fieldName: String): Boolean = fieldName in CONSTRAINT_NAMES
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        return when (field.fieldName) {
+            "all_of" -> Constraint.AllOf(typeReader.readTypeArgumentList(context, field))
+            "any_of" -> Constraint.AnyOf(typeReader.readTypeArgumentList(context, field))
+            "not" -> Constraint.Not(typeReader.readTypeArg(context, field,))
+            "one_of" -> Constraint.OneOf(typeReader.readTypeArgumentList(context, field))
+            "type" -> Constraint.Type(typeReader.readTypeArg(context, field))
+            else -> TODO("Unreachable")
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -24,19 +24,12 @@ import java.util.stream.Stream
 class ReaderTests {
 
     val unimplementedConstraints = listOf(
-        "all_of",
         "annotations",
-        "any_of",
         "contains",
-        "element",
-        "field_names", // This is implemented, but it requires type args, which are not implemented yet.
         "fields",
-        "not",
-        "one_of",
         "ordered_elements",
         "timestamp_offset",
         "timestamp_precision",
-        "type",
         "valid_values",
     )
     val unimplementedConstraintsRegex = Regex("constraints/(${unimplementedConstraints.joinToString("|")})")
@@ -49,12 +42,13 @@ class ReaderTests {
             !it.path.contains(unimplementedConstraintsRegex) &&
                 !it.path.contains("schema/") &&
                 !it.path.contains("imports/") &&
-                !it.path.contains("open_content/") &&
-                !it.path.contains("null_or.isl")
+                !it.path.contains("open_content/")
         },
         testNameFilter = {
             // readNamedType() and readSchema() are not implemented yet
-            !it.contains("readNamedType") && !it.contains("readSchema")
+            !it.contains("readNamedType") && !it.contains("readSchema") &&
+                // Reading variably occurring types has not been implemented yet
+                !it.contains("variably occurring type")
         }
     )
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ElementV2ReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ElementV2ReaderTest.kt
@@ -1,0 +1,108 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class ElementV2ReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'element'`() {
+        val reader = ElementV2Reader(mockk())
+        Assertions.assertTrue(reader.canRead("element"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'element'`() {
+        val reader = ElementV2Reader(mockk())
+        Assertions.assertFalse(reader.canRead("elephant"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'element' should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = ElementV2Reader(mockk())
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reading a valid element constraint should return a Element instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = ElementV2Reader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ element: symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.Element(mockType)
+        val actual = reader.readConstraint(context, struct["element"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a valid element constraint with 'distinct' should return a Element instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = ElementV2Reader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ element: distinct::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.Element(mockType, distinct = true)
+        val actual = reader.readConstraint(context, struct["element"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a valid element constraint with '$null_or' should return a ElementV2 instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = ElementV2Reader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ element: ${'$'}null_or::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.Element(mockType)
+        val actual = reader.readConstraint(context, struct["element"])
+        kotlin.test.assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a element constraint with any annotation other than 'distinct' or '$null_or' should throw exception`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = ElementV2Reader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ element: foo::symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        assertThrows<InvalidSchemaException> {
+            reader.readConstraint(context, struct["element"])
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReaderTest.kt
@@ -1,0 +1,79 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+@ExperimentalIonSchemaModel
+class LogicConstraintsReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @ValueSource(strings = ["all_of", "any_of", "not", "one_of", "type"])
+    @ParameterizedTest(name = "canRead should return true for {0}")
+    fun `canRead should return true for supported constraints`(fieldName: String) {
+        assertTrue(LogicConstraintsReader(mockk()).canRead(fieldName))
+    }
+
+    @Test
+    fun `canRead should return false for unsupported constraints`() {
+        val reader = LogicConstraintsReader(mockk())
+        Assertions.assertFalse(reader.canRead("two_of"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported constraint should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = LogicConstraintsReader(mockk())
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reading a single-arg logic constraint should return a constraint instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = LogicConstraintsReader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ type: symbol }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.Type(mockType)
+        val actual = reader.readConstraint(context, struct["type"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a multi-arg logic constraint should return a constraint instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = LogicConstraintsReader(typeReader)
+        val mockType1 = mockk<TypeArgument>()
+        val mockType2 = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArgumentList(any(), any()) } returns listOf(mockType1, mockType2)
+
+        val struct = ION.singleValue("""{ any_of: [symbol, string] }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.AnyOf(listOf(mockType1, mockType2))
+        val actual = reader.readConstraint(context, struct["any_of"])
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

Implements `readTypeArg()` and adds readers for some constraints that depend on type arguments (`element` and the "logic" constraints). Updates `ReaderTests` to cover all of the constraints readers that were added and the `$null_or` test cases.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
