### PR TITLE
Fix ktlintFormat build task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.6.20" apply false
-    id "org.jlleitschuh.gradle.ktlint" version "10.0.0" apply false
+    id "org.jlleitschuh.gradle.ktlint" version "11.3.2" apply false
     id "org.jetbrains.kotlinx.kover" version "0.7.0" apply false
 }
 
@@ -33,6 +33,7 @@ allprojects {
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"
     ktlint {
+        version = "0.40.0"
         outputToConsole = true
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

As part of #261, I seem to have broken the `ktlintFormat` Gradle tasks. (The `ktlintCheck` tasks still work fine though.) Turns out I needed to update the `ktlint` plugin when I updated to Gradle 8. This PR updates the `ktlint` plugin, but it keeps the ktlint rules version pinned at `0.40.0` so that I'm not introducing a lot of style related changes right now.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
