### PR TITLE
Adds readers for ordered_elements and fields constraints

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ buildscript {
 
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.6.20" apply false
-    id "org.jlleitschuh.gradle.ktlint" version "10.0.0" apply false
+    id "org.jlleitschuh.gradle.ktlint" version "11.3.2" apply false
     id "org.jetbrains.kotlinx.kover" version "0.7.0" apply false
 }
 
@@ -33,6 +33,7 @@ allprojects {
 
     apply plugin: "org.jlleitschuh.gradle.ktlint"
     ktlint {
+        version = "0.40.0"
         outputToConsole = true
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
@@ -29,6 +29,12 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
     }
 
     override fun readNamedType(ion: IonValue, failFast: Boolean): IonSchemaResult<NamedTypeDefinition, List<ReadError>> {
-        TODO()
+        val context = ReaderContext(failFast = failFast)
+        val typeDefinition = typeReader.readNamedTypeDefinition(context, ion)
+        return if (context.readErrors.isEmpty()) {
+            IonSchemaResult.Ok(typeDefinition)
+        } else {
+            IonSchemaResult.Err(context.readErrors)
+        }
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -11,6 +11,7 @@ import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.internal.util.getIslOptionalField
 import com.amazon.ionschema.internal.util.getIslRequiredField
 import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireExactAnnotations
 import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
 import com.amazon.ionschema.internal.util.islRequireOnlyExpectedFieldNames
@@ -50,7 +51,13 @@ internal class TypeReaderV2_0 : TypeReader {
     )
 
     override fun readNamedTypeDefinition(context: ReaderContext, ion: IonValue): NamedTypeDefinition {
-        TODO()
+        islRequireIonTypeNotNull<IonStruct>(ion) { "Named type definitions must be a non-null struct; was: $ion" }
+        islRequireExactAnnotations(ion, "type") { "Named type definitions must be annotated with 'type' and nothing else: $ion" }
+        islRequire(!ion.containsKey("occurs")) { "Named type definitions may not have an 'occurs' field: $ion" }
+        return NamedTypeDefinition(
+            ion.getIslRequiredField<IonSymbol>("name").stringValue(),
+            privateReadTypeDefinition(context, ion)
+        )
     }
 
     override fun readTypeArg(context: ReaderContext, ion: IonValue, checkAnnotations: Boolean): TypeArgument {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldsV2Reader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldsV2Reader.kt
@@ -1,0 +1,41 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+/**
+ * Reads the `fields` constraint for ISL 2.0 and higher
+ */
+@ExperimentalIonSchemaModel
+internal class FieldsV2Reader(private val typeReader: TypeReader) : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "fields"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireIonTypeNotNull<IonStruct>(field) { invalidConstraint(field, "must be a non-null struct") }
+        islRequireNoIllegalAnnotations(field, "closed") {
+            invalidConstraint(field, "argument may only be annotated with 'closed'")
+        }
+        require(!field.isEmpty)
+        require(field.map { it.fieldName }.distinct().size == field.size())
+        return Constraint.Fields(
+            fields = field.associate {
+                it.fieldName to typeReader.readVariablyOccurringTypeArg(
+                    context,
+                    it,
+                    VariablyOccurringTypeArgument.OCCURS_OPTIONAL
+                )
+            },
+            closed = field.hasTypeAnnotation("closed")
+        )
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/OrderedElementsReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/OrderedElementsReader.kt
@@ -1,0 +1,28 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument.Companion.OCCURS_REQUIRED
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class OrderedElementsReader(private val typeReader: TypeReader) : ConstraintReader {
+
+    override fun canRead(fieldName: String): Boolean = fieldName == "ordered_elements"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireIonTypeNotNull<IonList>(field) { invalidConstraint(field, "must be a non-null list") }
+        islRequireNoIllegalAnnotations(field) { invalidConstraint(field, "must not have annotations") }
+        return Constraint.OrderedElements(
+            field.map { typeReader.readVariablyOccurringTypeArg(context, it, defaultOccurs = OCCURS_REQUIRED) }
+        )
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -26,8 +26,6 @@ class ReaderTests {
     val unimplementedConstraints = listOf(
         "annotations",
         "contains",
-        "fields",
-        "ordered_elements",
         "timestamp_offset",
         "timestamp_precision",
         "valid_values",
@@ -46,9 +44,7 @@ class ReaderTests {
         },
         testNameFilter = {
             // readNamedType() and readSchema() are not implemented yet
-            !it.contains("readNamedType") && !it.contains("readSchema") &&
-                // Reading variably occurring types has not been implemented yet
-                !it.contains("variably occurring type")
+            !it.contains("readNamedType") && !it.contains("readSchema")
         }
     )
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -43,8 +43,8 @@ class ReaderTests {
                 !it.path.contains("open_content/")
         },
         testNameFilter = {
-            // readNamedType() and readSchema() are not implemented yet
-            !it.contains("readNamedType") && !it.contains("readSchema")
+            // readSchema() is not implemented yet
+            !it.contains("readSchema")
         }
     )
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldsV2ReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/FieldsV2ReaderTest.kt
@@ -1,0 +1,86 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument.Companion.OCCURS_OPTIONAL
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class FieldsV2ReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'fields'`() {
+        assertTrue(FieldsV2Reader(mockk()).canRead("fields"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'fields'`() {
+        val reader = FieldsV2Reader(mockk())
+        Assertions.assertFalse(reader.canRead("meadows"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = FieldsV2Reader(mockk())
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reading a valid fields constraint should return a Fields instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldsV2Reader(typeReader)
+        val mockTypeString = mockk<VariablyOccurringTypeArgument>()
+        val context = ReaderContext()
+
+        val struct = ION.singleValue("""{ fields: { foo: string } }""") as IonStruct
+
+        every { typeReader.readVariablyOccurringTypeArg(context, ION.newSymbol("string"), OCCURS_OPTIONAL) } returns mockTypeString
+
+        val expected = Constraint.Fields(mapOf("foo" to mockTypeString), closed = false)
+
+        val actual = reader.readConstraint(context, struct["fields"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading a valid fields constraint with 'closed' should return a Fields instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = FieldsV2Reader(typeReader)
+        val mockTypeString = mockk<VariablyOccurringTypeArgument>()
+        val mockTypeInt = mockk<VariablyOccurringTypeArgument>()
+        val context = ReaderContext()
+
+        val struct = ION.singleValue("""{ fields: closed::{ foo: string, bar: int } }""") as IonStruct
+
+        every { typeReader.readVariablyOccurringTypeArg(context, ION.newSymbol("string"), OCCURS_OPTIONAL) } returns mockTypeString
+        every { typeReader.readVariablyOccurringTypeArg(context, ION.newSymbol("int"), OCCURS_OPTIONAL) } returns mockTypeInt
+
+        val expected = Constraint.Fields(
+            mapOf(
+                "foo" to mockTypeString,
+                "bar" to mockTypeInt,
+            ),
+            closed = true
+        )
+
+        val actual = reader.readConstraint(context, struct["fields"])
+        assertEquals(expected, actual)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/OrderedElementsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/OrderedElementsReaderTest.kt
@@ -1,0 +1,63 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument.Companion.OCCURS_REQUIRED
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class OrderedElementsReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'ordered_elements'`() {
+        assertTrue(OrderedElementsReader(mockk()).canRead("ordered_elements"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'ordered_elements'`() {
+        val reader = OrderedElementsReader(mockk())
+        Assertions.assertFalse(reader.canRead("randomized_elements"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = OrderedElementsReader(mockk())
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reading a valid ordered_elements constraint should return an OrderedElements instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = OrderedElementsReader(typeReader)
+        val mockTypeString = mockk<VariablyOccurringTypeArgument>()
+        val mockTypeInt = mockk<VariablyOccurringTypeArgument>()
+        val context = ReaderContext()
+
+        val struct = ION.singleValue("""{ ordered_elements: [ string, int ] }""") as IonStruct
+
+        every { typeReader.readVariablyOccurringTypeArg(context, ION.newSymbol("string"), OCCURS_REQUIRED) } returns mockTypeString
+        every { typeReader.readVariablyOccurringTypeArg(context, ION.newSymbol("int"), OCCURS_REQUIRED) } returns mockTypeInt
+
+        val expected = Constraint.OrderedElements(listOf(mockTypeString, mockTypeInt))
+
+        val actual = reader.readConstraint(context, struct["ordered_elements"])
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

Commit: "Adds readers..."
* Adds real implementation of `TypeReaderV2_0.readVariablyOccurringTypeArg()`
* Adds ConstraintReader implementations for `fields` and `ordered_elements`

Commit: "Adds implementation of readNamedType"
* Adds implementation of `readNamedType`. Updates tests so as not to skip "readNamedType" tests.
* This should deal with some of the missing coverage... it wasn't actually running all of the happy case tests in Ion Schema Tests.

Commit: "Fixes..."
* As part of #261, I seem to have broken the `ktlintFormat` Gradle tasks. (The `ktlintCheck` tasks still work fine though.) Turns out I needed to update the `ktlint` plugin when I updated to Gradle 8. This PR updates the `ktlint` plugin, but it keeps the ktlint rules version pinned at `0.40.0` so that I'm not introducing a lot of style related changes right now.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
