### PR TITLE
Adds reader for timestamp_offset and timestamp_precision

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -32,6 +32,8 @@ import com.amazon.ionschema.reader.internal.constraints.LogicConstraintsReader
 import com.amazon.ionschema.reader.internal.constraints.OrderedElementsReader
 import com.amazon.ionschema.reader.internal.constraints.PrecisionReader
 import com.amazon.ionschema.reader.internal.constraints.RegexReader
+import com.amazon.ionschema.reader.internal.constraints.TimestampOffsetReader
+import com.amazon.ionschema.reader.internal.constraints.TimestampPrecisionReader
 import com.amazon.ionschema.reader.internal.constraints.ValidValuesReader
 import com.amazon.ionschema.util.toBag
 
@@ -49,6 +51,8 @@ internal class TypeReaderV2_0 : TypeReader {
         OrderedElementsReader(this),
         PrecisionReader(),
         RegexReader(IonSchemaVersion.v2_0),
+        TimestampOffsetReader(),
+        TimestampPrecisionReader(),
         ValidValuesReader(),
     )
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReader.kt
@@ -1,0 +1,34 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonString
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireElementType
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.internal.util.islRequireNotEmpty
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TimestampOffsetValue
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class TimestampOffsetReader : ConstraintReader {
+
+    override fun canRead(fieldName: String): Boolean = fieldName == "timestamp_offset"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireIonTypeNotNull<IonList>(field) { invalidConstraint(field, "must be a non-null, non-empty list") }
+        islRequire(field.isNotEmpty()) { invalidConstraint(field, "must be a non-null, non-empty list") }
+        islRequireNoIllegalAnnotations(field) { invalidConstraint(field, "must not have annotations") }
+        return Constraint.TimestampOffset(
+            field.islRequireElementType<IonString>("timestamp offset list")
+                .islRequireNotEmpty("timestamp offset list")
+                .map { TimestampOffsetValue.parse(it.stringValue()) }
+        )
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReader.kt
@@ -1,0 +1,18 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.toTimestampPrecisionRange
+
+@ExperimentalIonSchemaModel
+internal class TimestampPrecisionReader : ConstraintReader {
+
+    override fun canRead(fieldName: String): Boolean = fieldName == "timestamp_precision"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+        return Constraint.TimestampPrecision(field.toTimestampPrecisionRange())
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -26,8 +26,6 @@ class ReaderTests {
     val unimplementedConstraints = listOf(
         "annotations",
         "contains",
-        "timestamp_offset",
-        "timestamp_precision",
     )
     val unimplementedConstraintsRegex = Regex("constraints/(${unimplementedConstraints.joinToString("|")})")
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReaderTest.kt
@@ -1,0 +1,55 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TimestampOffsetValue
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class TimestampOffsetReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'timestamp_offset'`() {
+        assertTrue(TimestampOffsetReader().canRead("timestamp_offset"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'timestamp_offset'`() {
+        val reader = TimestampOffsetReader()
+        Assertions.assertFalse(reader.canRead("stardate_offset"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = TimestampOffsetReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reader should be able to read some timestamp offsets`() {
+        val struct = ION.singleValue("""{ timestamp_offset: ["+00:30", "+01:30"] }""") as IonStruct
+        val reader = TimestampOffsetReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampOffset(
+            listOf(
+                TimestampOffsetValue.fromMinutes(30),
+                TimestampOffsetValue.fromMinutes(90),
+            )
+        )
+        val result = reader.readConstraint(context, struct["timestamp_offset"])
+        assertEquals(expected, result)
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReaderTest.kt
@@ -1,0 +1,112 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ContinuousRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TimestampPrecisionRange
+import com.amazon.ionschema.model.TimestampPrecisionValue
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class TimestampPrecisionReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'timestamp_precision'`() {
+        assertTrue(TimestampPrecisionReader().canRead("timestamp_precision"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'timestamp_precision'`() {
+        val reader = TimestampPrecisionReader()
+        Assertions.assertFalse(reader.canRead("stardate_precision"))
+    }
+
+    @Test
+    fun `reading a field that is not a supported field should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `reader should be able to read a single value`() {
+        val struct = ION.singleValue("""{ timestamp_precision: year }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampPrecision(TimestampPrecisionRange(TimestampPrecisionValue.Year))
+        val result = reader.readConstraint(context, struct["timestamp_precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range`() {
+        val struct = ION.singleValue("""{ timestamp_precision: range::[month, day] }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampPrecision(
+            TimestampPrecisionRange(
+                ContinuousRange.Limit.Closed(TimestampPrecisionValue.Month),
+                ContinuousRange.Limit.Closed(TimestampPrecisionValue.Day),
+            )
+        )
+        val result = reader.readConstraint(context, struct["timestamp_precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded upper endpoint`() {
+        val struct = ION.singleValue("""{ timestamp_precision: range::[minute, max] }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampPrecision(
+            TimestampPrecisionRange(
+                ContinuousRange.Limit.Closed(TimestampPrecisionValue.Minute),
+                ContinuousRange.Limit.Unbounded(),
+            )
+        )
+        val result = reader.readConstraint(context, struct["timestamp_precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with unbounded lower endpoint`() {
+        val struct = ION.singleValue("""{ timestamp_precision: range::[min, second] }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampPrecision(
+            TimestampPrecisionRange(
+                ContinuousRange.Limit.Unbounded(),
+                ContinuousRange.Limit.Closed(TimestampPrecisionValue.Second),
+            )
+        )
+        val result = reader.readConstraint(context, struct["timestamp_precision"])
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `reader should be able to read a range with exclusive endpoint`() {
+        val struct = ION.singleValue("""{ timestamp_precision: range::[millisecond, exclusive::microsecond] }""") as IonStruct
+        val reader = TimestampPrecisionReader()
+        val context = ReaderContext()
+        val expected = Constraint.TimestampPrecision(
+            TimestampPrecisionRange(
+                ContinuousRange.Limit.Closed(TimestampPrecisionValue.Millisecond),
+                ContinuousRange.Limit.Open(TimestampPrecisionValue.Microsecond),
+            )
+        )
+        val result = reader.readConstraint(context, struct["timestamp_precision"])
+        assertEquals(expected, result)
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

Adds readers for `timestamp_offset` and `timestamp_precision`; updates the ReaderTests accordingly.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
