### PR TITLE
Add readers for annotations and contains constraints

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -22,6 +22,8 @@ import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+import com.amazon.ionschema.reader.internal.constraints.AnnotationsV2Reader
+import com.amazon.ionschema.reader.internal.constraints.ContainsReader
 import com.amazon.ionschema.reader.internal.constraints.ElementV2Reader
 import com.amazon.ionschema.reader.internal.constraints.ExponentReader
 import com.amazon.ionschema.reader.internal.constraints.FieldNamesReader
@@ -41,6 +43,8 @@ import com.amazon.ionschema.util.toBag
 internal class TypeReaderV2_0 : TypeReader {
 
     private val constraintReaders = listOf(
+        AnnotationsV2Reader(this),
+        ContainsReader(),
         ElementV2Reader(this),
         ExponentReader(),
         FieldNamesReader(this),

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
@@ -1,0 +1,49 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonStruct
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.internal.util.islRequire
+import com.amazon.ionschema.internal.util.islRequireElementType
+import com.amazon.ionschema.internal.util.islRequireIonNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class AnnotationsV2Reader(private val typeReader: TypeReader) : ConstraintReader {
+    override fun canRead(fieldName: String): Boolean = fieldName == "annotations"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        return when (field) {
+            is IonList -> {
+                islRequireIonNotNull(field) { invalidConstraint(field, "must not be null.list") }
+                islRequireNoIllegalAnnotations(field, "closed", "required") {
+                    invalidConstraint(field, "list of annotations may not be annotated other than 'closed' and 'required'")
+                }
+                islRequire(field.typeAnnotations.isNotEmpty()) {
+                    invalidConstraint(field, "list of annotations must be annotated with at least one of 'closed' and 'required'")
+                }
+                field.islRequireElementType<IonSymbol>("list of annotations")
+
+                val modifier = if (field.hasTypeAnnotation("closed") && field.hasTypeAnnotation("required")) {
+                    Constraint.AnnotationsV2.Modifier.ClosedAndRequired
+                } else if (field.hasTypeAnnotation("required")) {
+                    Constraint.AnnotationsV2.Modifier.Required
+                } else {
+                    Constraint.AnnotationsV2.Modifier.Closed
+                }
+                Constraint.AnnotationsV2.create(modifier, field.filterIsInstance<IonSymbol>())
+            }
+            is IonStruct, is IonSymbol -> Constraint.AnnotationsV2(typeReader.readTypeArg(context, field))
+            else -> throw InvalidSchemaException(invalidConstraint(field, "must be a type argument (symbol or struct) or a list of valid annotations"))
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReader.kt
@@ -1,0 +1,24 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonList
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
+import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.invalidConstraint
+
+@ExperimentalIonSchemaModel
+internal class ContainsReader : ConstraintReader {
+
+    override fun canRead(fieldName: String): Boolean = fieldName == "contains"
+
+    override fun readConstraint(context: ReaderContext, field: IonValue): Constraint {
+        check(canRead(field.fieldName))
+
+        islRequireIonTypeNotNull<IonList>(field) { invalidConstraint(field, "must be a non-null list") }
+        islRequireNoIllegalAnnotations(field) { invalidConstraint(field, "must not have annotations") }
+        return Constraint.Contains(field.map { it.clone() })
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -23,19 +23,12 @@ import java.util.stream.Stream
 @ExperimentalIonSchemaModel
 class ReaderTests {
 
-    val unimplementedConstraints = listOf(
-        "annotations",
-        "contains",
-    )
-    val unimplementedConstraintsRegex = Regex("constraints/(${unimplementedConstraints.joinToString("|")})")
-
     @Nested
     inner class IonSchema_2_0 : TestFactory by ReaderTestsRunner(
         version = IonSchemaVersion.v2_0,
         reader = IonSchemaReaderV2_0(),
         additionalFileFilter = {
-            !it.path.contains(unimplementedConstraintsRegex) &&
-                !it.path.contains("schema/") &&
+            !it.path.contains("schema/") &&
                 !it.path.contains("imports/") &&
                 !it.path.contains("open_content/")
         },

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2ReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2ReaderTest.kt
@@ -1,0 +1,185 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.model.ValidValue
+import com.amazon.ionschema.reader.internal.ReaderContext
+import com.amazon.ionschema.reader.internal.TypeReader
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class AnnotationsV2ReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'annotations'`() {
+        val reader = AnnotationsV2Reader(mockk())
+        assertTrue(reader.canRead("annotations"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'annotations'`() {
+        val reader = AnnotationsV2Reader(mockk())
+        assertFalse(reader.canRead("bananotations"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'annotations' should throw IllegalStateException`() {
+        val reader = AnnotationsV2Reader(mockk())
+
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> {
+            reader.readConstraint(context, struct["foo"])
+        }
+    }
+
+    @Test
+    fun `reading an annotations constraint with a type argument should return an AnnotationsV2 instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+        val mockType = mockk<TypeArgument>()
+
+        every { typeReader.readTypeArg(any(), any(), any()) } returns mockType
+
+        val struct = ION.singleValue("""{ annotations: { valid_values: [[a, b, c]] } }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.AnnotationsV2(mockType)
+        val actual = reader.readConstraint(context, struct["annotations"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading an annotations constraint with a list of required annotations should return an AnnotationsV2 instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: required::[a, b, c] }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.AnnotationsV2(
+            TypeArgument.InlineType(
+                TypeDefinition(
+                    setOf(
+                        Constraint.Contains(setOf("a", "b", "c").map(ION::newSymbol))
+                    )
+                )
+            )
+        )
+        val actual = reader.readConstraint(context, struct["annotations"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading an annotations constraint with a list of closed annotations should return an AnnotationsV2 instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: closed::[a, b, c] }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.AnnotationsV2(
+            TypeArgument.InlineType(
+                TypeDefinition(
+                    setOf(
+                        Constraint.Element(
+                            TypeArgument.InlineType(
+                                TypeDefinition(
+                                    setOf(
+                                        Constraint.ValidValues(setOf("a", "b", "c").map { ValidValue.Value(ION.newSymbol(it)) })
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val actual = reader.readConstraint(context, struct["annotations"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading an annotations constraint with a list of closed and required annotations should return an AnnotationsV2 instance`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: closed::required::[a, b, c] }""") as IonStruct
+        val context = ReaderContext()
+
+        val expected = Constraint.AnnotationsV2(
+            TypeArgument.InlineType(
+                TypeDefinition(
+                    setOf(
+                        Constraint.Contains(setOf("a", "b", "c").map(ION::newSymbol)),
+                        Constraint.Element(
+                            TypeArgument.InlineType(
+                                TypeDefinition(
+                                    setOf(
+                                        Constraint.ValidValues(setOf("a", "b", "c").map { ValidValue.Value(ION.newSymbol(it)) })
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+            )
+        )
+        val actual = reader.readConstraint(context, struct["annotations"])
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `reading an annotations constraint with invalid annotation on list should throw exception`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: flux_capacitor::[a, b, c] }""") as IonStruct
+        val context = ReaderContext()
+
+        assertThrows<InvalidSchemaException> {
+            reader.readConstraint(context, struct["annotations"])
+        }
+    }
+
+    @Test
+    fun `reading an annotations constraint with no annotation on list should throw exception`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: [a, b, c] }""") as IonStruct
+        val context = ReaderContext()
+
+        assertThrows<InvalidSchemaException> {
+            reader.readConstraint(context, struct["annotations"])
+        }
+    }
+
+    @Test
+    fun `reading an annotations constraint with invalid list contents should throw exception`() {
+        val typeReader = mockk<TypeReader>()
+        val reader = AnnotationsV2Reader(typeReader)
+
+        val struct = ION.singleValue("""{ annotations: closed::[a, 1, 2023-04-05T06:07:08Z] }""") as IonStruct
+        val context = ReaderContext()
+
+        assertThrows<InvalidSchemaException> {
+            reader.readConstraint(context, struct["annotations"])
+        }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReaderTest.kt
@@ -1,0 +1,57 @@
+package com.amazon.ionschema.reader.internal.constraints
+
+import com.amazon.ion.IonStruct
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.ReaderContext
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+
+@ExperimentalIonSchemaModel
+class ContainsReaderTest {
+
+    private companion object {
+        val ION = IonSystemBuilder.standard().build()
+    }
+
+    @Test
+    fun `canRead should return true for 'contains'`() {
+        val reader = ContainsReader()
+        Assertions.assertTrue(reader.canRead("contains"))
+    }
+
+    @Test
+    fun `canRead should return false for any field other than 'contains'`() {
+        val reader = ContainsReader()
+        Assertions.assertFalse(reader.canRead("pertains"))
+    }
+
+    @Test
+    fun `reading a field that is not named 'contains' should throw IllegalStateException`() {
+        val struct = ION.singleValue("""{ foo: symbol }""") as IonStruct
+        val reader = ContainsReader()
+        val context = ReaderContext()
+        assertThrows<IllegalStateException> { reader.readConstraint(context, struct["foo"]) }
+    }
+
+    @Test
+    fun `read contains with some values should return contains constraint`() {
+        val struct = ION.singleValue("""{ contains: [a, 1, true] }""") as IonStruct
+        val reader = ContainsReader()
+        val context = ReaderContext()
+        val actual = reader.readConstraint(context, struct["contains"])
+        assertEquals(
+            Constraint.Contains(
+                listOf(
+                    ION.newSymbol("a"),
+                    ION.newInt(1),
+                    ION.newBool(true),
+                )
+            ),
+            actual
+        )
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256

**Description of changes:**

Adds readers for Annotations (v2) and Contains constraints. Updates `ReaderTests`.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
