### PR TITLE
Fixes the way TimestampPrecisionValue is modeled

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
@@ -40,13 +40,13 @@ internal fun IonValue.toTimestampPrecisionRange(): TimestampPrecisionRange {
     return when (this) {
         is IonList -> toContinuousRange { sym: IonSymbol ->
             TimestampPrecisionValue.fromSymbolTextOrNull(sym.stringValue())
-                ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.values().joinToString { it.symbolText }}, min, or max: $this")
+                ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.valueSymbolTexts().joinToString() }, min, or max: $this")
         }
         is IonSymbol -> {
             islRequireIonNotNull(this) { "Timestamp precision value cannot be null; was: $this" }
             islRequireNoIllegalAnnotations(this) { "Timestamp precision value may not have annotations" }
             val precision = TimestampPrecisionValue.fromSymbolTextOrNull(stringValue())
-                ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.values().joinToString { it.symbolText }}, min, or max: $this")
+                ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.valueSymbolTexts().joinToString() }, min, or max: $this")
             ContinuousRange(precision)
         }
         else -> throw InvalidSchemaException("Invalid range; not an ion list: $this")

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/model/TimestampPrecisionValueTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/model/TimestampPrecisionValueTest.kt
@@ -1,16 +1,17 @@
 package com.amazon.ionschema.model
 
+import com.amazon.ion.Timestamp
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.MethodSource
 
 class TimestampPrecisionValueTest {
 
     @ParameterizedTest(name = "symbolText for {0}")
-    @EnumSource
+    @MethodSource("com.amazon.ionschema.model.TimestampPrecisionValue#values")
     fun `test symbolText`(tpv: TimestampPrecisionValue) {
         val expected = when (tpv) {
             TimestampPrecisionValue.Year -> "year"
@@ -21,15 +22,33 @@ class TimestampPrecisionValueTest {
             TimestampPrecisionValue.Millisecond -> "millisecond"
             TimestampPrecisionValue.Microsecond -> "microsecond"
             TimestampPrecisionValue.Nanosecond -> "nanosecond"
+            else -> null
         }
-        assertEquals(expected, tpv.symbolText)
+        assertEquals(expected, tpv.toSymbolTextOrNull())
     }
 
     @ParameterizedTest(name = "fromSymbolTextOrNull for {0}")
-    @EnumSource
+    @MethodSource("com.amazon.ionschema.model.TimestampPrecisionValue#values")
     fun `test fromSymbolTextOrNull`(tpv: TimestampPrecisionValue) {
-        val symbolText = tpv.symbolText
+        val symbolText = tpv.toSymbolTextOrNull()!!
         assertEquals(tpv, TimestampPrecisionValue.fromSymbolTextOrNull(symbolText))
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "-4, 2023T",
+        "-3, 2023-04T",
+        "-2, 2023-04-05T",
+        "-1, 2023-04-05T00:00Z",
+        " 0, 2023-04-05T00:00:00Z",
+        " 1, 2023-04-05T00:00:00.0Z",
+        " 2, 2023-04-05T00:00:00.00Z",
+        " 3, 2023-04-05T00:00:00.000Z",
+        " 4, 2023-04-05T00:00:00.0000Z",
+    )
+    fun test(expectedIntValue: Int, timestamp: String) {
+        val actual = TimestampPrecisionValue.fromTimestamp(Timestamp.valueOf(timestamp))
+        assertEquals(expectedIntValue, actual.intValue)
     }
 
     @Test
@@ -38,14 +57,9 @@ class TimestampPrecisionValueTest {
     }
 
     @ParameterizedTest(name = "fromSymbolText for {0}")
-    @EnumSource
+    @MethodSource("com.amazon.ionschema.model.TimestampPrecisionValue#values")
     fun `test fromSymbolText`(tpv: TimestampPrecisionValue) {
-        val symbolText = tpv.symbolText
-        assertEquals(tpv, TimestampPrecisionValue.fromSymbolText(symbolText))
-    }
-
-    @Test
-    fun `fromSymbolTextOrNull should throw exception when not a valid timestamp precision value`() {
-        assertThrows<IllegalArgumentException> { TimestampPrecisionValue.fromSymbolText("stardate") }
+        val symbolText = tpv.toSymbolTextOrNull()!!
+        assertEquals(tpv, TimestampPrecisionValue.fromSymbolTextOrNull(symbolText))
     }
 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #270 

**Description of changes:**

Changes `TimestampPrecisionValue` from an enum to a class. The class has a bunch of static constant values so that its public API is a little like an enum. This change fixes the problem with the `TimestampPrecisionRange` because we can (internally) construct a `TimestampPrecisionValue` for any timestamp to be compared against the range.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
