### PR TITLE
Adds changes to read full schema document

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/util/IonValueExtensions.kt
@@ -47,6 +47,11 @@ internal fun <T : IonValue> T.markReadOnly(): T {
 }
 
 /**
+ * Guarantees that the returned value is read-only, creating a read-only clone if this value is not already read-only.
+ */
+internal fun <T : IonValue> T.getReadOnlyClone(): T = if (this.isReadOnly) this else this.clone().markReadOnly() as T
+
+/**
  * Returns the Ion Schema type name for an IonType.
  * TLDR; "DATAGRAM" is "document" and every other name is simply converted to lowercase.
  */

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
@@ -21,7 +21,7 @@ interface IonSchemaReader {
      * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
      * errors.
      */
-    fun readSchema(document: List<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>>
+    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<Pair<SchemaDocument, Iterator<IonValue>>, List<ReadError>>
 
     /**
      * Reads a [SchemaDocument], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
@@ -21,7 +21,7 @@ interface IonSchemaReader {
      * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
      * errors.
      */
-    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<Pair<SchemaDocument, Iterator<IonValue>>, List<ReadError>>
+    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>>
 
     /**
      * Reads a [SchemaDocument], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
@@ -1,40 +1,123 @@
 package com.amazon.ionschema.reader
 
 import com.amazon.ion.IonValue
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.IonSchema_2_0
+import com.amazon.ionschema.internal.util.getReadOnlyClone
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.SchemaDocument
 import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.reader.internal.FooterReader
+import com.amazon.ionschema.reader.internal.HeaderReader
 import com.amazon.ionschema.reader.internal.ReadError
 import com.amazon.ionschema.reader.internal.ReaderContext
 import com.amazon.ionschema.reader.internal.TypeReaderV2_0
+import com.amazon.ionschema.reader.internal.isFooter
+import com.amazon.ionschema.reader.internal.isHeader
+import com.amazon.ionschema.reader.internal.isTopLevelOpenContent
+import com.amazon.ionschema.reader.internal.isType
+import com.amazon.ionschema.reader.internal.readCatching
 import com.amazon.ionschema.util.IonSchemaResult
 
 @OptIn(ExperimentalIonSchemaModel::class)
 class IonSchemaReaderV2_0 : IonSchemaReader {
     private val typeReader = TypeReaderV2_0()
+    private val headerReader = HeaderReader(IonSchemaVersion.v2_0)
+    private val footerReader = FooterReader { it in userReservedFields.footer || !IonSchema_2_0.RESERVED_WORDS_REGEX.matches(it) }
 
-    override fun readSchema(document: List<IonValue>, failFast: Boolean): IonSchemaResult<SchemaDocument, List<ReadError>> {
-        TODO()
+    private enum class ReaderState(val location: String) {
+        Init("before version marker"),
+        BeforeHeader("before schema header"),
+        ReadingTypes("while reading types"),
+    }
+
+    override fun readSchema(document: Iterable<IonValue>, failFast: Boolean): IonSchemaResult<Pair<SchemaDocument, Iterator<IonValue>>, List<ReadError>> {
+        val context = ReaderContext(failFast = failFast)
+
+        val documentIterator = document.iterator()
+
+        val schemaDocument = try { iterateSchema(documentIterator, context) } catch (e: InvalidSchemaException) { null }
+
+        return if (schemaDocument != null && context.readErrors.isEmpty()) {
+            IonSchemaResult.Ok(schemaDocument to documentIterator)
+        } else {
+            IonSchemaResult.Err(context.readErrors) { InvalidSchemaException("$it") }
+        }
     }
 
     override fun readType(ion: IonValue, failFast: Boolean): IonSchemaResult<TypeDefinition, List<ReadError>> {
         val context = ReaderContext(failFast = failFast)
-        val typeDefinition = typeReader.readOrphanedTypeDefinition(context, ion)
-        return if (context.readErrors.isEmpty()) {
+        val typeDefinition = try { typeReader.readOrphanedTypeDefinition(context, ion) } catch (e: InvalidSchemaException) { null }
+        return if (typeDefinition != null && context.readErrors.isEmpty()) {
             IonSchemaResult.Ok(typeDefinition)
         } else {
-            IonSchemaResult.Err(context.readErrors)
+            IonSchemaResult.Err(context.readErrors) { InvalidSchemaException("$it") }
         }
     }
 
     override fun readNamedType(ion: IonValue, failFast: Boolean): IonSchemaResult<NamedTypeDefinition, List<ReadError>> {
         val context = ReaderContext(failFast = failFast)
-        val typeDefinition = typeReader.readNamedTypeDefinition(context, ion)
-        return if (context.readErrors.isEmpty()) {
+        val typeDefinition = try { typeReader.readNamedTypeDefinition(context, ion) } catch (e: InvalidSchemaException) { null }
+        return if (typeDefinition != null && context.readErrors.isEmpty()) {
             IonSchemaResult.Ok(typeDefinition)
         } else {
-            IonSchemaResult.Err(context.readErrors)
+            IonSchemaResult.Err(context.readErrors) { InvalidSchemaException("$it") }
         }
+    }
+
+    private fun iterateSchema(documentIterator: Iterator<IonValue>, context: ReaderContext): SchemaDocument? {
+        val items = mutableListOf<SchemaDocument.Item>()
+        var state = ReaderState.Init
+        while (documentIterator.hasNext()) {
+            val value = documentIterator.next()
+            when {
+                IonSchemaVersion.isVersionMarker(value) -> {
+                    if (state == ReaderState.Init && IonSchemaVersion.fromIonSymbolOrNull(value) == IonSchemaVersion.v2_0) {
+                        state = ReaderState.BeforeHeader
+                    } else {
+                        context.reportError(ReadError(value, "unexpected version marker ${state.location}"))
+                    }
+                }
+                isHeader(value) -> {
+                    if (state == ReaderState.BeforeHeader) {
+                        readCatching(context, value) { headerReader.readHeader(context, value) }?.let(items::add)
+                        state = ReaderState.ReadingTypes
+                    } else {
+                        context.reportError(ReadError(value, "schema header encountered ${state.location}"))
+                    }
+                }
+                isType(value) -> {
+                    if (state > ReaderState.Init) {
+                        readCatching(context, value) { typeReader.readNamedTypeDefinition(context, value) }
+                            ?.let { items.add(SchemaDocument.Item.Type(it)) }
+                        state = ReaderState.ReadingTypes
+                    } else {
+                        context.reportError(ReadError(value, "type definition encountered ${state.location}"))
+                    }
+                }
+                isFooter(value) -> {
+                    if (state > ReaderState.Init) {
+                        readCatching(context, value) { items.add(footerReader.readFooter(context, value)) }
+                        break
+                    } else {
+                        context.reportError(ReadError(value, "schema footer encountered ${state.location}"))
+                    }
+                }
+                state > ReaderState.Init -> {
+                    // If we've already seen the version marker, then handle open content
+                    if (isTopLevelOpenContent(value)) {
+                        items.add(SchemaDocument.Item.OpenContent(value.getReadOnlyClone()))
+                    } else {
+                        context.reportError(ReadError(value, "invalid top level value ${state.location}"))
+                    }
+                }
+                else -> {
+                    // Drop anything before the version marker.
+                }
+            }
+        }
+        return SchemaDocument(null, IonSchemaVersion.v2_0, items.toList())
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
@@ -33,7 +33,7 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
         ReadingTypes("while reading types"),
     }
 
-    override fun readSchema(document: Iterable<IonValue>, failFast: Boolean): IonSchemaResult<Pair<SchemaDocument, Iterator<IonValue>>, List<ReadError>> {
+    override fun readSchema(document: Iterable<IonValue>, failFast: Boolean): IonSchemaResult<SchemaDocument, List<ReadError>> {
         val context = ReaderContext(failFast = failFast)
 
         val documentIterator = document.iterator()
@@ -41,7 +41,7 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
         val schemaDocument = try { iterateSchema(documentIterator, context) } catch (e: InvalidSchemaException) { null }
 
         return if (schemaDocument != null && context.readErrors.isEmpty()) {
-            IonSchemaResult.Ok(schemaDocument to documentIterator)
+            IonSchemaResult.Ok(schemaDocument)
         } else {
             IonSchemaResult.Err(context.readErrors) { InvalidSchemaException("$it") }
         }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReaderContext.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ReaderContext.kt
@@ -47,12 +47,12 @@ internal class ReaderContext(
         get() = _readErrors.toList()
 
     /**
-     * Reports a [ReadError] to this [ReaderContext].
-     * If [failFast] is false, adds an error to this [ReaderContext].
-     * If [failFast] is true, throws the error as an [InvalidSchemaException].
+     * Reports a [ReadError] to this [ReaderContext], adding it to [readErrors].
+     * If [failFast] is `true`, also throws the error as an [InvalidSchemaException].
      */
     fun reportError(error: ReadError) {
         if (failFast) {
+            _readErrors.add(error)
             InvalidSchemaException.failFast(error)
         } else {
             _readErrors.add(error)

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReaderV2_0.kt
@@ -8,6 +8,7 @@ import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.IonSchema_2_0
 import com.amazon.ionschema.internal.util.getIslOptionalField
 import com.amazon.ionschema.internal.util.getIslRequiredField
 import com.amazon.ionschema.internal.util.islRequire
@@ -150,7 +151,8 @@ internal class TypeReaderV2_0 : TypeReader {
                 if (readerForThisConstraint != null) {
                     constraints.add(readerForThisConstraint.readConstraint(context, field))
                 } else {
-                    // TODO: Make sure that it's a legal field name for open content
+                    val isLegalOpenContentFieldName = !IonSchema_2_0.RESERVED_WORDS_REGEX.matches(fieldName) || fieldName in context.userReservedFields.type
+                    islRequire(isLegalOpenContentFieldName) { "illegal use of field name '$fieldName'" }
                     openContent.add(fieldName to field)
                 }
             }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/util.kt
@@ -1,8 +1,13 @@
 package com.amazon.ionschema.reader.internal
 
+import com.amazon.ion.IonStruct
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.internal.util.IonSchema_2_0
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 
 /**
  * Helper function to catch exceptions and convert them into [ReadError] or rethrow if they are a fast-fail exception.
@@ -34,4 +39,36 @@ internal inline fun <T : Any> Iterable<IonValue>.readAllCatching(context: Reader
  */
 internal fun invalidConstraint(value: IonValue, reason: String, constraintName: String = value.fieldName): String {
     return "Illegal argument for '$constraintName' constraint; $reason: $value"
+}
+
+@OptIn(ExperimentalContracts::class)
+internal fun isHeader(value: IonValue): Boolean {
+    contract { returns(true) implies (value is IonStruct) }
+    return value is IonStruct && !value.isNullValue && arrayOf("schema_header").contentDeepEquals(value.typeAnnotations)
+}
+
+@OptIn(ExperimentalContracts::class)
+internal fun isFooter(value: IonValue): Boolean {
+    contract { returns(true) implies (value is IonStruct) }
+    return value is IonStruct && !value.isNullValue && arrayOf("schema_footer").contentDeepEquals(value.typeAnnotations)
+}
+
+@OptIn(ExperimentalContracts::class)
+internal fun isType(value: IonValue): Boolean {
+    contract { returns(true) implies (value is IonStruct) }
+    return value is IonStruct && !value.isNullValue && arrayOf("type").contentDeepEquals(value.typeAnnotations)
+}
+
+/**
+ * Checks whether a given value is allowed as top-level open content.
+ * See https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#open-content
+ */
+internal fun isTopLevelOpenContent(value: IonValue): Boolean {
+    if (IonSchemaVersion.isVersionMarker(value)) {
+        return false
+    }
+    if (value.typeAnnotations.any { IonSchema_2_0.RESERVED_WORDS_REGEX.matches(it) }) {
+        return false
+    }
+    return true
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/Bag.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/Bag.kt
@@ -14,4 +14,8 @@ class Bag<out E>(elements: List<E>) : Collection<E> by elements {
     }
 
     override fun hashCode(): Int = this.sumBy { it.hashCode() }
+
+    override fun toString(): String {
+        return "Bag[${this.joinToString()}]"
+    }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
@@ -1,0 +1,324 @@
+package com.amazon.ionschema.reader
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.InvalidSchemaException
+import com.amazon.ionschema.IonSchemaVersion
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.HeaderImport
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.model.UserReservedFields
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class IonSchemaReaderV2_0Tests {
+
+    val ION = IonSystemBuilder.standard().build()
+    val reader = IonSchemaReaderV2_0()
+    val typeTextWithMultipleErrors = """
+            type::{
+              valid_values: until_recently::["Ni!"],
+              not: "it"
+            }
+        """
+
+    val namedTypeTextWithMultipleErrors = """
+            type::{
+              name: foo,
+              codepoint_length: three,
+              utf8_byte_length: five,
+              valid_values: [1, 2, 5, "Three, sir!", 3],
+            }
+        """
+
+    val schemaTextWithMultipleErrors = """
+            ${'$'}ion_schema_2_0
+            $namedTypeTextWithMultipleErrors
+            $typeTextWithMultipleErrors
+            type::null.symbol
+        """
+
+    @Test
+    fun `readSchema can read a schema with types`() {
+        val ionStream = ION.loader.load(
+            """
+            ${'$'}ion_schema_2_0
+            type::{
+              name: type1,
+              type: string,
+              codepoint_length: 3,
+            }
+            type::{
+              name: type2,
+              type: symbol,
+              utf8_byte_length: 5
+            } 
+        """
+        )
+
+        val result = reader.readSchema(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            SchemaDocument(
+                id = null,
+                ionSchemaVersion = IonSchemaVersion.v2_0,
+                items = listOf(
+                    SchemaDocument.Item.Type(
+                        NamedTypeDefinition(
+                            typeName = "type1",
+                            typeDefinition = TypeDefinition(
+                                constraints = setOf(
+                                    Constraint.Type(TypeArgument.Reference("string")),
+                                    Constraint.CodepointLength(DiscreteIntRange(3))
+                                )
+                            ),
+                        )
+                    ),
+                    SchemaDocument.Item.Type(
+                        NamedTypeDefinition(
+                            typeName = "type2",
+                            typeDefinition = TypeDefinition(
+                                constraints = setOf(
+                                    Constraint.Type(TypeArgument.Reference("symbol")),
+                                    Constraint.Utf8ByteLength(DiscreteIntRange(5))
+                                )
+                            ),
+                        )
+                    )
+                )
+            ),
+            result.unwrap().first
+        )
+        assertFalse(result.unwrap().second.hasNext())
+    }
+
+    @Test
+    fun `readSchema can read a schema with a header`() {
+        val ionStream = ION.loader.load(
+            """
+            ${'$'}ion_schema_2_0
+            schema_header::{
+              imports: [
+                { id: "foo.isl" }
+              ],
+              user_reserved_fields: {
+                type: [foo],  
+              }
+            }
+        """
+        )
+
+        val result = reader.readSchema(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            SchemaDocument(
+                id = null,
+                ionSchemaVersion = IonSchemaVersion.v2_0,
+                items = listOf(
+                    SchemaDocument.Item.Header(
+                        imports = listOf(HeaderImport.Wildcard("foo.isl")),
+                        userReservedFields = UserReservedFields(type = setOf("foo"))
+                    ),
+                )
+            ),
+            result.unwrap().first
+        )
+        assertFalse(result.unwrap().second.hasNext())
+    }
+
+    @Test
+    fun `readSchema can read a schema with a footer and returns an iterator with all of the content after the footer`() {
+        val ionStream = ION.loader.load(
+            """
+            ${'$'}ion_schema_2_0
+            schema_footer::{}
+            abc
+            def
+            ${'$'}ion_schema_1_0
+        """
+        )
+
+        val result = reader.readSchema(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            SchemaDocument(null, IonSchemaVersion.v2_0, listOf(SchemaDocument.Item.Footer())),
+            result.unwrap().first
+        )
+        val iterator = result.unwrap().second
+        assertEquals(ION.singleValue("abc"), iterator.next())
+        assertEquals(ION.singleValue("def"), iterator.next())
+        assertEquals(ION.singleValue("\$ion_schema_1_0"), iterator.next())
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `readSchema can read a schema with open content`() {
+        val ionStream = ION.loader.load(
+            """
+            foo
+            ${'$'}ion_schema_2_0
+            bar // Only bar is open content. Both 'foo' and 'baz' are outside the schema. 
+            schema_footer::{}
+            baz
+        """
+        )
+
+        val result = reader.readSchema(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            SchemaDocument(
+                id = null,
+                ionSchemaVersion = IonSchemaVersion.v2_0,
+                items = listOf(
+                    SchemaDocument.Item.OpenContent(ION.singleValue("bar")),
+                    SchemaDocument.Item.Footer(),
+                )
+            ),
+            result.unwrap().first
+        )
+        val iterator = result.unwrap().second
+        assertEquals(ION.singleValue("baz"), iterator.next())
+        assertFalse(iterator.hasNext())
+    }
+
+    @Test
+    fun `readSchema can return errors in a schema using slow-fail`() {
+        val ionStream = ION.loader.load(schemaTextWithMultipleErrors)
+
+        val result = reader.readSchema(ionStream, failFast = false)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got more than one error.
+        assertTrue(errs.size > 1)
+    }
+
+    @Test
+    fun `readSchema can return errors in a schema using fast-fail`() {
+        val ionStream = ION.loader.load(schemaTextWithMultipleErrors)
+
+        val result = reader.readSchema(ionStream, failFast = true)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got exactly one error.
+        assertTrue(errs.size == 1)
+    }
+
+    @Test
+    fun `readSchemaOrThrow throws an InvalidSchemaException for a bad schema`() {
+        val ionStream = ION.loader.load(schemaTextWithMultipleErrors)
+
+        assertThrows<InvalidSchemaException> { reader.readSchemaOrThrow(ionStream) }
+    }
+
+    @Test
+    fun `readType can read a type`() {
+        val ionStream = ION.singleValue("type::{ type: string, codepoint_length: 5 }")
+
+        val result = reader.readType(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            TypeDefinition(
+                constraints = setOf(
+                    Constraint.Type(TypeArgument.Reference("string")),
+                    Constraint.CodepointLength(DiscreteIntRange(5))
+                )
+            ),
+            result.unwrap()
+        )
+    }
+
+    @Test
+    fun `readType can return errors in a type using slow-fail`() {
+        val ionStream = ION.singleValue(typeTextWithMultipleErrors)
+
+        val result = reader.readType(ionStream, failFast = false)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got more than one error.
+        assertTrue(errs.size > 1)
+    }
+
+    @Test
+    fun `readType can return errors in a type using fast-fail`() {
+        val ionStream = ION.singleValue(typeTextWithMultipleErrors)
+
+        val result = reader.readType(ionStream, failFast = true)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got exactly one error.
+        assertTrue(errs.size == 1)
+    }
+
+    @Test
+    fun `readTypeOrThrow throws an InvalidSchemaException for a bad type`() {
+        val ionStream = ION.singleValue(typeTextWithMultipleErrors)
+
+        assertThrows<InvalidSchemaException> { reader.readTypeOrThrow(ionStream) }
+    }
+
+    @Test
+    fun `readNamedType can read a type`() {
+        val ionStream = ION.singleValue("type::{ name: foo, type: string }")
+
+        val result = reader.readNamedType(ionStream)
+
+        assertTrue(result.isOk())
+        assertEquals(
+            NamedTypeDefinition(
+                typeName = "foo",
+                typeDefinition = TypeDefinition(
+                    constraints = setOf(Constraint.Type(TypeArgument.Reference("string")))
+                )
+            ),
+            result.unwrap()
+        )
+    }
+
+    @Test
+    fun `readNamedType can return errors in a type using slow-fail`() {
+        val ionStream = ION.singleValue(namedTypeTextWithMultipleErrors)
+
+        val result = reader.readNamedType(ionStream, failFast = false)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got more than one error.
+        assertTrue(errs.size > 1)
+    }
+
+    @Test
+    fun `readNamedType can return errors in a type using fast-fail`() {
+        val ionStream = ION.singleValue(namedTypeTextWithMultipleErrors)
+
+        val result = reader.readNamedType(ionStream, failFast = true)
+
+        assertTrue(result.isErr())
+        val errs = result.errValueOrNull()!!
+        // The actual errors are not important. Just check that we got exactly one error.
+        assertTrue(errs.size == 1)
+    }
+
+    @Test
+    fun `readNamedTypeOrThrow throws an InvalidSchemaException for a bad type`() {
+        val ionStream = ION.singleValue(namedTypeTextWithMultipleErrors)
+
+        assertThrows<InvalidSchemaException> { reader.readNamedTypeOrThrow(ionStream) }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

#256 

**Description of changes:**

- Changes the signature of `readSchema` so that it returns a `Pair<SchemaDocument, Iterator<IonValue>>`—essentially, it returns the `SchemaDocument` and any unread `IonValue`s.
- Adds some utility functions for identifying top level content (header, footer, type, open content).
- Adds implementation of `readSchema` with a lot of tests.
- Fixes a bug with the `reportError` function that showed up while testing `readSchema`. Basically, fast-fail wasn't working properly because it was only throwing on fast fail without adding the error to the ReadContext.
- Another incidental change is adding a useful `toString()` for `Bag`. I realized that the default impl was giving me things like `Bag@398c0a`, so I changed it to something useful.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.


_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
