### PR TITLE
Ease-of-use improvements for ISL model

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Constraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Constraint.kt
@@ -19,7 +19,7 @@ interface Constraint {
      * See relevant section in [ISL 1.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#all_of) and
      * [ISL 2.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#all_of).
      */
-    data class AllOf(val types: TypeArgumentList) : Constraint
+    data class AllOf(val types: TypeArguments) : Constraint
 
     /**
      * Represents the `annotations` constraint for Ion Schema 1.0.
@@ -43,11 +43,11 @@ interface Constraint {
              * [simple syntax](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#simple-syntax).
              */
             @JvmStatic
-            fun create(modifier: Modifier, annotationSymbols: List<IonSymbol>): AnnotationsV2 {
+            fun create(modifier: Modifier, annotationSymbols: Set<IonSymbol>): AnnotationsV2 {
                 val annotationsConstraints = mutableSetOf<Constraint>()
                 // If closed, constrain using `valid_values`
                 if (modifier == Modifier.Closed || modifier == Modifier.ClosedAndRequired) {
-                    val validValues = annotationSymbols.map { ValidValue.Value(it) }
+                    val validValues = annotationSymbols.mapToSet { ValidValue.Value(it) }
                     annotationsConstraints.add(
                         Element(TypeArgument.InlineType(TypeDefinition(setOf(ValidValues(validValues)))))
                     )
@@ -66,7 +66,7 @@ interface Constraint {
      * See relevant section in [ISL 1.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#any_of) and
      * [ISL 2.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#any_of).
      */
-    data class AnyOf(val types: TypeArgumentList) : Constraint
+    data class AnyOf(val types: TypeArguments) : Constraint
 
     /**
      * Represents the `byte_length` constraint.
@@ -106,7 +106,7 @@ interface Constraint {
      * See relevant section in [ISL 1.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#contains) and
      * [ISL 2.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#contains).
      */
-    data class Contains(val values: List<IonValue>) : Constraint
+    data class Contains(val values: Set<IonValue>) : Constraint
 
     /**
      * Represents the `element` constraint.
@@ -155,7 +155,7 @@ interface Constraint {
      * See relevant section in [ISL 1.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-1-0/spec#one_of) and
      * [ISL 2.0 spec](https://amazon-ion.github.io/ion-schema/docs/isl-2-0/spec#one_of).
      */
-    data class OneOf(val types: TypeArgumentList) : Constraint
+    data class OneOf(val types: TypeArguments) : Constraint
 
     /**
      * Represents the `ordered_elements` constraint.
@@ -221,7 +221,7 @@ interface Constraint {
      *
      * @see TimestampOffsetValue
      */
-    data class TimestampOffset(val offsets: List<TimestampOffsetValue>) : Constraint
+    data class TimestampOffset(val offsets: Set<TimestampOffsetValue>) : Constraint
 
     /**
      * Represents the `timestamp_precision` constraint.
@@ -257,5 +257,5 @@ interface Constraint {
      *
      * @see ValidValue
      */
-    data class ValidValues(val values: List<ValidValue>) : Constraint
+    data class ValidValues(val values: Set<ValidValue>) : Constraint
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
@@ -16,16 +16,16 @@ data class ContinuousRange<T : Comparable<T>>(val start: Limit<T>, val end: Limi
     private constructor(value: Limit.Closed<T>) : this(value, value)
     constructor(value: T) : this(Limit.Closed(value))
 
-    sealed class Limit<T : Comparable<T>> {
+    sealed class Limit<out T> {
         abstract val value: T?
 
         interface Bounded<T> { val value: T }
         data class Closed<T : Comparable<T>>(override val value: T) : Limit<T>(), Bounded<T>
         data class Open<T : Comparable<T>>(override val value: T) : Limit<T>(), Bounded<T>
-        class Unbounded<T : Comparable<T>> : Limit<T>() {
+        object Unbounded : Limit<Nothing>() {
             override val value: Nothing? get() = null
 
-            override fun equals(other: Any?) = other is Unbounded<*>
+            override fun equals(other: Any?) = other is Unbounded
             override fun hashCode() = 0
         }
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
@@ -15,8 +15,8 @@ class DiscreteIntRange private constructor(private val delegate: ContinuousRange
     // Because we never construct Open bounds, we cannot accidentally create an empty range.
     constructor(start: Int?, endInclusive: Int?) : this(
         ContinuousRange(
-            start?.let { ContinuousRange.Limit.Closed(it) } ?: ContinuousRange.Limit.Unbounded(),
-            endInclusive?.let { ContinuousRange.Limit.Closed(it) } ?: ContinuousRange.Limit.Unbounded()
+            start?.let { ContinuousRange.Limit.Closed(it) } ?: ContinuousRange.Limit.Unbounded,
+            endInclusive?.let { ContinuousRange.Limit.Closed(it) } ?: ContinuousRange.Limit.Unbounded
         )
     )
 

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/NamedTypeDefinition.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/NamedTypeDefinition.kt
@@ -4,4 +4,4 @@ package com.amazon.ionschema.model
  * Represents a top-level, named type definition.
  */
 @ExperimentalIonSchemaModel
-data class NamedTypeDefinition(val typeName: String, val typeDefinition: TypeDefinition)
+data class NamedTypeDefinition(val typeName: String, val typeDefinition: TypeDefinition) : SchemaDocument.Content

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaDocument.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaDocument.kt
@@ -32,7 +32,7 @@ data class SchemaDocument(
         data class Type(val value: NamedTypeDefinition) : Item()
 
         data class Header(
-            val imports: List<HeaderImport> = emptyList(),
+            val imports: Set<HeaderImport> = emptySet(),
             val userReservedFields: UserReservedFields = UserReservedFields(),
             val openContent: OpenContentFields = emptyBag()
         ) : Item()

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaDocument.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaDocument.kt
@@ -25,7 +25,7 @@ data class SchemaDocument(
     }
 
     /**
-     * Represents a top-level values in a schema document.
+     * Represents a top-level value in a schema document.
      * Implemented by [NamedTypeDefinition], [SchemaHeader], [SchemaFooter], and [OpenContent].
      * This interface is not intended to be implemented by users of the library.
      */

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaFooter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaFooter.kt
@@ -1,0 +1,9 @@
+package com.amazon.ionschema.model
+
+import com.amazon.ionschema.util.emptyBag
+
+/**
+ * Represents the schema footer for all versions of Ion Schema.
+ */
+@ExperimentalIonSchemaModel
+data class SchemaFooter(val openContent: OpenContentFields = emptyBag()) : SchemaDocument.Content

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaHeader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/SchemaHeader.kt
@@ -1,0 +1,13 @@
+package com.amazon.ionschema.model
+
+import com.amazon.ionschema.util.emptyBag
+
+/**
+ * Represents the schema header for all versions of Ion Schema.
+ */
+@ExperimentalIonSchemaModel
+data class SchemaHeader(
+    val imports: Set<HeaderImport> = emptySet(),
+    val userReservedFields: UserReservedFields = UserReservedFields(),
+    val openContent: OpenContentFields = emptyBag()
+) : SchemaDocument.Content

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
@@ -15,10 +15,10 @@ import com.amazon.ionschema.util.Bag
 typealias OpenContentFields = Bag<Pair<String, IonValue>>
 
 /**
- * Convenience alias for a list of [TypeArgument].
+ * Convenience alias for a set of [TypeArgument].
  */
 @ExperimentalIonSchemaModel
-typealias TypeArgumentList = List<TypeArgument>
+typealias TypeArguments = Set<TypeArgument>
 
 /**
  * A [ContinuousRange] of [Timestamp], represented as a [ConsistentTimestamp].

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/util.kt
@@ -15,3 +15,11 @@ internal fun not(c: Constraint): Constraint {
 internal fun inlineType(constraints: Set<Constraint>): TypeArgument.InlineType {
     return TypeArgument.InlineType(TypeDefinition(constraints))
 }
+
+/**
+ * Returns a set containing the results of applying the given [transform] function
+ * to each element in the original collection.
+ */
+inline fun <T, R> Iterable<T>.mapToSet(transform: (T) -> R): Set<R> {
+    return mapTo(HashSet(), transform)
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0.kt
@@ -68,7 +68,7 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
     }
 
     private fun iterateSchema(documentIterator: Iterator<IonValue>, context: ReaderContext): SchemaDocument? {
-        val items = mutableListOf<SchemaDocument.Item>()
+        val items = mutableListOf<SchemaDocument.Content>()
         var state = ReaderState.Init
         while (documentIterator.hasNext()) {
             val value = documentIterator.next()
@@ -91,7 +91,7 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
                 isType(value) -> {
                     if (state > ReaderState.Init) {
                         readCatching(context, value) { typeReader.readNamedTypeDefinition(context, value) }
-                            ?.let { items.add(SchemaDocument.Item.Type(it)) }
+                            ?.let { items.add(it) }
                         state = ReaderState.ReadingTypes
                     } else {
                         context.reportError(ReadError(value, "type definition encountered ${state.location}"))
@@ -108,7 +108,7 @@ class IonSchemaReaderV2_0 : IonSchemaReader {
                 state > ReaderState.Init -> {
                     // If we've already seen the version marker, then handle open content
                     if (isTopLevelOpenContent(value)) {
-                        items.add(SchemaDocument.Item.OpenContent(value.getReadOnlyClone()))
+                        items.add(SchemaDocument.OpenContent(value.getReadOnlyClone()))
                     } else {
                         context.reportError(ReadError(value, "invalid top level value ${state.location}"))
                     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/FooterReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/FooterReader.kt
@@ -6,13 +6,13 @@ import com.amazon.ionschema.internal.util.islRequire
 import com.amazon.ionschema.internal.util.islRequireExactAnnotations
 import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
-import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.SchemaFooter
 import com.amazon.ionschema.util.toBag
 
 @ExperimentalIonSchemaModel
 internal class FooterReader(private val isValidOpenContentField: ReaderContext.(String) -> Boolean) {
 
-    fun readFooter(context: ReaderContext, footerValue: IonValue): SchemaDocument.Item.Footer {
+    fun readFooter(context: ReaderContext, footerValue: IonValue): SchemaFooter {
         islRequireIonTypeNotNull<IonStruct>(footerValue) { "schema_footer must be a non-null struct; was: $footerValue" }
         islRequireExactAnnotations(footerValue, "schema_footer") { "schema_footer may not have extra annotations" }
 
@@ -21,6 +21,6 @@ internal class FooterReader(private val isValidOpenContentField: ReaderContext.(
         islRequire(unexpectedFieldNames.isEmpty()) { "Found illegal field names $unexpectedFieldNames in schema footer: $footerValue" }
 
         val openContent = footerValue.map { it.fieldName to it }.toBag()
-        return SchemaDocument.Item.Footer(openContent)
+        return SchemaFooter(openContent)
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/HeaderReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/HeaderReader.kt
@@ -19,7 +19,7 @@ import com.amazon.ionschema.internal.util.islRequireOnlyExpectedFieldNames
 import com.amazon.ionschema.internal.util.islRequireZeroOrOneElements
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.HeaderImport
-import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.SchemaHeader
 import com.amazon.ionschema.model.UserReservedFields
 import com.amazon.ionschema.util.toBag
 
@@ -29,7 +29,7 @@ internal class HeaderReader(private val ionSchemaVersion: IonSchemaVersion) {
     /**
      * Reads the header
      */
-    fun readHeader(context: ReaderContext, headerValue: IonValue): SchemaDocument.Item.Header {
+    fun readHeader(context: ReaderContext, headerValue: IonValue): SchemaHeader {
         islRequire(!context.foundHeader) { "Only one schema header is allowed in a schema document." }
         islRequire(!context.foundAnyType) { "Schema header must appear before any types." }
         context.foundHeader = true
@@ -52,7 +52,7 @@ internal class HeaderReader(private val ionSchemaVersion: IonSchemaVersion) {
             .map { it.fieldName to it }
             .toBag()
 
-        return SchemaDocument.Item.Header(imports, context.userReservedFields, openContent)
+        return SchemaHeader(imports, context.userReservedFields, openContent)
     }
 
     /**

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/HeaderReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/HeaderReader.kt
@@ -86,9 +86,9 @@ internal class HeaderReader(private val ionSchemaVersion: IonSchemaVersion) {
             ?: emptySet()
     }
 
-    private fun loadHeaderImports(context: ReaderContext, header: IonStruct): List<HeaderImport> {
+    private fun loadHeaderImports(context: ReaderContext, header: IonStruct): Set<HeaderImport> {
         // If there's no imports field, then there's nothing to do
-        val imports = header.getIslOptionalField<IonList>("imports") ?: return emptyList()
+        val imports = header.getIslOptionalField<IonList>("imports") ?: return emptySet()
 
         islRequireNoIllegalAnnotations(imports) { "'imports' list may not be annotated" }
 
@@ -109,7 +109,7 @@ internal class HeaderReader(private val ionSchemaVersion: IonSchemaVersion) {
                 typeField != null -> HeaderImport.Type(schemaId, typeField.stringValue())
                 else -> HeaderImport.Wildcard(schemaId)
             }
-        }
+        }.toSet()
     }
 
     private fun validateFieldNamesInHeader(context: ReaderContext, header: IonStruct) {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/TypeReader.kt
@@ -8,7 +8,7 @@ import com.amazon.ionschema.model.DiscreteIntRange
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.TypeArgument
-import com.amazon.ionschema.model.TypeArgumentList
+import com.amazon.ionschema.model.TypeArguments
 import com.amazon.ionschema.model.VariablyOccurringTypeArgument
 
 @ExperimentalIonSchemaModel
@@ -30,12 +30,12 @@ internal interface TypeReader {
     fun readVariablyOccurringTypeArg(context: ReaderContext, ion: IonValue, defaultOccurs: DiscreteIntRange): VariablyOccurringTypeArgument
 
     /**
-     * Reads a [TypeArgumentList].
+     * Reads a [TypeArguments].
      */
-    fun readTypeArgumentList(context: ReaderContext, ion: IonValue): TypeArgumentList {
+    fun readTypeArgumentList(context: ReaderContext, ion: IonValue): TypeArguments {
         val constraintName = ion.fieldName!!
         islRequireIonTypeNotNull<IonList>(ion) { "Illegal argument for '$constraintName' constraint; must be non-null Ion list: $ion" }
         islRequire(ion.typeAnnotations.isEmpty()) { "Illegal argument for '$constraintName' constraint; must not have annotations; was: $ion" }
-        return ion.readAllCatching(context) { readTypeArg(context, it) }
+        return ion.readAllCatching(context) { readTypeArg(context, it) }.toSet()
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
@@ -40,7 +40,7 @@ internal class AnnotationsV2Reader(private val typeReader: TypeReader) : Constra
                 } else {
                     Constraint.AnnotationsV2.Modifier.Closed
                 }
-                Constraint.AnnotationsV2.create(modifier, field.filterIsInstance<IonSymbol>())
+                Constraint.AnnotationsV2.create(modifier, field.filterIsInstance<IonSymbol>().toSet())
             }
             is IonStruct, is IonSymbol -> Constraint.AnnotationsV2(typeReader.readTypeArg(context, field))
             else -> throw InvalidSchemaException(invalidConstraint(field, "must be a type argument (symbol or struct) or a list of valid annotations"))

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReader.kt
@@ -6,6 +6,7 @@ import com.amazon.ionschema.internal.util.islRequireIonTypeNotNull
 import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.mapToSet
 import com.amazon.ionschema.reader.internal.ReaderContext
 import com.amazon.ionschema.reader.internal.invalidConstraint
 
@@ -19,6 +20,6 @@ internal class ContainsReader : ConstraintReader {
 
         islRequireIonTypeNotNull<IonList>(field) { invalidConstraint(field, "must be a non-null list") }
         islRequireNoIllegalAnnotations(field) { invalidConstraint(field, "must not have annotations") }
-        return Constraint.Contains(field.map { it.clone() })
+        return Constraint.Contains(field.mapToSet { it.clone() })
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReader.kt
@@ -11,6 +11,7 @@ import com.amazon.ionschema.internal.util.islRequireNotEmpty
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.TimestampOffsetValue
+import com.amazon.ionschema.model.mapToSet
 import com.amazon.ionschema.reader.internal.ReaderContext
 import com.amazon.ionschema.reader.internal.invalidConstraint
 
@@ -28,7 +29,7 @@ internal class TimestampOffsetReader : ConstraintReader {
         return Constraint.TimestampOffset(
             field.islRequireElementType<IonString>("timestamp offset list")
                 .islRequireNotEmpty("timestamp offset list")
-                .map { TimestampOffsetValue.parse(it.stringValue()) }
+                .mapToSet { TimestampOffsetValue.parse(it.stringValue()) }
         )
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReader.kt
@@ -10,6 +10,7 @@ import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.ValidValue
+import com.amazon.ionschema.model.mapToSet
 import com.amazon.ionschema.reader.internal.ReaderContext
 import com.amazon.ionschema.reader.internal.invalidConstraint
 import com.amazon.ionschema.reader.internal.toNumberRange
@@ -27,7 +28,7 @@ internal class ValidValuesReader : ConstraintReader {
         islRequireNoIllegalAnnotations(field, "range") { invalidConstraint(field, "must be a range or an unannotated list of values ") }
         val theList = if (field.hasTypeAnnotation("range")) listOf(field) else field
 
-        val theValidValues = theList.map {
+        val theValidValues = theList.mapToSet {
             if (it.hasTypeAnnotation("range") && it is IonList) {
                 when {
                     it.any { x -> x is IonTimestamp } -> ValidValue.IonTimestampRange(it.toTimestampRange())

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
@@ -120,7 +120,7 @@ private inline fun <T : Comparable<T>, reified IV : IonValue> IonList.readContin
     val b = get(boundaryPosition.idx) ?: throw InvalidSchemaException("Invalid range; missing $boundaryPosition boundary value: $this")
     return if (b is IonSymbol && b.stringValue() == boundaryPosition.symbol) {
         islRequire(b.typeAnnotations.isEmpty()) { "Invalid range; min/max may not be annotated: $this" }
-        ContinuousRange.Limit.Unbounded()
+        ContinuousRange.Limit.Unbounded
     } else {
         val value = islRequireIonTypeNotNull<IV>(b) { "Invalid range; $boundaryPosition boundary of range must be '${boundaryPosition.symbol}' or a non-null ${IV::class.simpleName}" }.let(valueFn)
         val exclusive = readBoundaryExclusivity(boundaryPosition)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/model/ContinuousRangeTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/model/ContinuousRangeTest.kt
@@ -115,7 +115,7 @@ class ContinuousRangeTest {
 
         fun closed(d: Double) = d.let { ContinuousRange.Limit.Closed(d) }
         fun open(d: Double) = d.let { ContinuousRange.Limit.Open(d) }
-        fun unbounded() = ContinuousRange.Limit.Unbounded<Double>()
+        fun unbounded() = ContinuousRange.Limit.Unbounded
 
         /** case for `testContains` */
         private fun case(range: ContinuousRange<Double>, value: Double, isContained: Boolean) = Triple(range, value, isContained)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/model/SchemaDocumentTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/model/SchemaDocumentTest.kt
@@ -2,7 +2,6 @@ package com.amazon.ionschema.model
 
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionschema.IonSchemaVersion
-import com.amazon.ionschema.model.SchemaDocument.Item
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertIterableEquals
 import org.junit.jupiter.api.Assertions.assertNull
@@ -23,8 +22,8 @@ class SchemaDocumentTest {
 
     @Test
     fun `test get header when header present`() {
-        val header = Item.Header()
-        val footer = Item.Footer()
+        val header = SchemaHeader()
+        val footer = SchemaFooter()
         val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(header, footer))
         assertSame(header, schema.header)
     }
@@ -37,8 +36,8 @@ class SchemaDocumentTest {
 
     @Test
     fun `test get footer when footer present`() {
-        val header = Item.Header()
-        val footer = Item.Footer()
+        val header = SchemaHeader()
+        val footer = SchemaFooter()
         val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(header, footer))
         assertSame(footer, schema.footer)
     }
@@ -63,7 +62,7 @@ class SchemaDocumentTest {
                 constraints = setOf(),
             )
         )
-        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(Item.Type(type0), Item.Type(type1)))
+        val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, listOf(type0, type1))
         assertEquals(2, schema.declaredTypes.size)
         assertSame(type0, schema.declaredTypes["type0"])
         assertSame(type1, schema.declaredTypes["type1"])
@@ -90,16 +89,16 @@ class SchemaDocumentTest {
             )
         )
         val schemaItems = listOf(
-            Item.OpenContent(ION.newInt(1)),
-            Item.OpenContent(ION.newInt(2)),
-            Item.Header(),
-            Item.OpenContent(ION.newInt(3)),
-            Item.Type(type0),
-            Item.OpenContent(ION.newInt(4)),
-            Item.Type(type1),
-            Item.OpenContent(ION.newInt(5)),
-            Item.Footer(),
-            Item.OpenContent(ION.newInt(6)),
+            SchemaDocument.OpenContent(ION.newInt(1)),
+            SchemaDocument.OpenContent(ION.newInt(2)),
+            SchemaHeader(),
+            SchemaDocument.OpenContent(ION.newInt(3)),
+            type0,
+            SchemaDocument.OpenContent(ION.newInt(4)),
+            type1,
+            SchemaDocument.OpenContent(ION.newInt(5)),
+            SchemaFooter(),
+            SchemaDocument.OpenContent(ION.newInt(6)),
         )
         val schema = SchemaDocument("schema.isl", IonSchemaVersion.v2_0, schemaItems)
         assertIterableEquals(schemaItems, schema.items)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
@@ -125,7 +125,7 @@ class IonSchemaReaderV2_0Tests {
                 ionSchemaVersion = IonSchemaVersion.v2_0,
                 items = listOf(
                     SchemaDocument.Item.Header(
-                        imports = listOf(HeaderImport.Wildcard("foo.isl")),
+                        imports = setOf(HeaderImport.Wildcard("foo.isl")),
                         userReservedFields = UserReservedFields(type = setOf("foo"))
                     ),
                 )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
@@ -9,6 +9,8 @@ import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.HeaderImport
 import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.SchemaFooter
+import com.amazon.ionschema.model.SchemaHeader
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.UserReservedFields
@@ -72,27 +74,23 @@ class IonSchemaReaderV2_0Tests {
                 id = null,
                 ionSchemaVersion = IonSchemaVersion.v2_0,
                 items = listOf(
-                    SchemaDocument.Item.Type(
-                        NamedTypeDefinition(
-                            typeName = "type1",
-                            typeDefinition = TypeDefinition(
-                                constraints = setOf(
-                                    Constraint.Type(TypeArgument.Reference("string")),
-                                    Constraint.CodepointLength(DiscreteIntRange(3))
-                                )
-                            ),
-                        )
+                    NamedTypeDefinition(
+                        typeName = "type1",
+                        typeDefinition = TypeDefinition(
+                            constraints = setOf(
+                                Constraint.Type(TypeArgument.Reference("string")),
+                                Constraint.CodepointLength(DiscreteIntRange(3))
+                            )
+                        ),
                     ),
-                    SchemaDocument.Item.Type(
-                        NamedTypeDefinition(
-                            typeName = "type2",
-                            typeDefinition = TypeDefinition(
-                                constraints = setOf(
-                                    Constraint.Type(TypeArgument.Reference("symbol")),
-                                    Constraint.Utf8ByteLength(DiscreteIntRange(5))
-                                )
-                            ),
-                        )
+                    NamedTypeDefinition(
+                        typeName = "type2",
+                        typeDefinition = TypeDefinition(
+                            constraints = setOf(
+                                Constraint.Type(TypeArgument.Reference("symbol")),
+                                Constraint.Utf8ByteLength(DiscreteIntRange(5))
+                            )
+                        ),
                     )
                 )
             ),
@@ -124,7 +122,7 @@ class IonSchemaReaderV2_0Tests {
                 id = null,
                 ionSchemaVersion = IonSchemaVersion.v2_0,
                 items = listOf(
-                    SchemaDocument.Item.Header(
+                    SchemaHeader(
                         imports = setOf(HeaderImport.Wildcard("foo.isl")),
                         userReservedFields = UserReservedFields(type = setOf("foo"))
                     ),
@@ -159,12 +157,12 @@ class IonSchemaReaderV2_0Tests {
                 id = null,
                 ionSchemaVersion = IonSchemaVersion.v2_0,
                 items = listOf(
-                    SchemaDocument.Item.OpenContent(ION.singleValue("bar1")),
-                    SchemaDocument.Item.Header(),
-                    SchemaDocument.Item.OpenContent(ION.singleValue("bar2")),
-                    SchemaDocument.Item.Type(NamedTypeDefinition("foo", TypeDefinition(emptySet(), emptyBag()))),
-                    SchemaDocument.Item.OpenContent(ION.singleValue("bar3")),
-                    SchemaDocument.Item.Footer(),
+                    SchemaDocument.OpenContent(ION.singleValue("bar1")),
+                    SchemaHeader(),
+                    SchemaDocument.OpenContent(ION.singleValue("bar2")),
+                    NamedTypeDefinition("foo", TypeDefinition(emptySet(), emptyBag())),
+                    SchemaDocument.OpenContent(ION.singleValue("bar3")),
+                    SchemaFooter(),
                 )
             ),
             result.unwrap()

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/FooterReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/FooterReaderTest.kt
@@ -4,7 +4,7 @@ import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.internal.util.IonSchema_2_0
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
-import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.SchemaFooter
 import com.amazon.ionschema.model.UserReservedFields
 import com.amazon.ionschema.util.bagOf
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,7 +21,7 @@ class FooterReaderTest {
     fun `readFooter can read an empty footer`() {
         val context = ReaderContext()
         val footer = footerReader.readFooter(context, ION.singleValue("schema_footer::{}"))
-        assertEquals(SchemaDocument.Item.Footer(), footer)
+        assertEquals(SchemaFooter(), footer)
     }
 
     @Test
@@ -29,7 +29,7 @@ class FooterReaderTest {
         val context = ReaderContext()
         val footer = footerReader.readFooter(context, ION.singleValue("schema_footer::{_foo:1,_bar:2}"))
 
-        val expected = SchemaDocument.Item.Footer(
+        val expected = SchemaFooter(
             openContent = bagOf(
                 "_foo" to ION.newInt(1),
                 "_bar" to ION.newInt(2),
@@ -44,7 +44,7 @@ class FooterReaderTest {
         val context = ReaderContext()
         context.userReservedFields = UserReservedFields(footer = setOf("foo", "bar"))
         val footer = footerReader.readFooter(context, ION.singleValue("schema_footer::{foo:1,bar:2}"))
-        val expected = SchemaDocument.Item.Footer(
+        val expected = SchemaFooter(
             openContent = bagOf(
                 "foo" to ION.newInt(1),
                 "bar" to ION.newInt(2),

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/HeaderReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/HeaderReaderTest.kt
@@ -28,7 +28,7 @@ class HeaderReaderTest {
     fun `readHeader can read a wildcard import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl" } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = listOf(HeaderImport.Wildcard("foo.isl")))
+        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Wildcard("foo.isl")))
         assertEquals(expected, header)
     }
 
@@ -36,7 +36,7 @@ class HeaderReaderTest {
     fun `readHeader can read a type import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl", type: bar } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = listOf(HeaderImport.Type("foo.isl", "bar")))
+        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Type("foo.isl", "bar")))
         assertEquals(expected, header)
     }
 
@@ -44,7 +44,7 @@ class HeaderReaderTest {
     fun `readHeader can read an aliased import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl", type: bar, as: baz } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = listOf(HeaderImport.Type("foo.isl", "bar", "baz")))
+        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Type("foo.isl", "bar", "baz")))
         assertEquals(expected, header)
     }
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/HeaderReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/HeaderReaderTest.kt
@@ -5,7 +5,7 @@ import com.amazon.ionschema.InvalidSchemaException
 import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.HeaderImport
-import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.SchemaHeader
 import com.amazon.ionschema.model.UserReservedFields
 import com.amazon.ionschema.util.bagOf
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -21,14 +21,14 @@ class HeaderReaderTest {
     fun `readHeader can read an empty header`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("schema_header::{}"))
-        assertEquals(SchemaDocument.Item.Header(), header)
+        assertEquals(SchemaHeader(), header)
     }
 
     @Test
     fun `readHeader can read a wildcard import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl" } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Wildcard("foo.isl")))
+        val expected = SchemaHeader(imports = setOf(HeaderImport.Wildcard("foo.isl")))
         assertEquals(expected, header)
     }
 
@@ -36,7 +36,7 @@ class HeaderReaderTest {
     fun `readHeader can read a type import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl", type: bar } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Type("foo.isl", "bar")))
+        val expected = SchemaHeader(imports = setOf(HeaderImport.Type("foo.isl", "bar")))
         assertEquals(expected, header)
     }
 
@@ -44,7 +44,7 @@ class HeaderReaderTest {
     fun `readHeader can read an aliased import`() {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ imports: [ { id: "foo.isl", type: bar, as: baz } ] }"""))
-        val expected = SchemaDocument.Item.Header(imports = setOf(HeaderImport.Type("foo.isl", "bar", "baz")))
+        val expected = SchemaHeader(imports = setOf(HeaderImport.Type("foo.isl", "bar", "baz")))
         assertEquals(expected, header)
     }
 
@@ -53,7 +53,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ user_reserved_fields: { schema_header: [foo] } }"""))
         val expectedUserReservedFields = UserReservedFields(header = setOf("foo"))
-        val expectedHeader = SchemaDocument.Item.Header(userReservedFields = expectedUserReservedFields)
+        val expectedHeader = SchemaHeader(userReservedFields = expectedUserReservedFields)
         assertEquals(expectedHeader, header)
         assertEquals(expectedUserReservedFields, context.userReservedFields)
     }
@@ -63,7 +63,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ user_reserved_fields: { schema_footer: [foo] } }"""))
         val expectedUserReservedFields = UserReservedFields(footer = setOf("foo"))
-        val expectedHeader = SchemaDocument.Item.Header(userReservedFields = expectedUserReservedFields)
+        val expectedHeader = SchemaHeader(userReservedFields = expectedUserReservedFields)
         assertEquals(expectedHeader, header)
         assertEquals(expectedUserReservedFields, context.userReservedFields)
     }
@@ -73,7 +73,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("""schema_header::{ user_reserved_fields: { type: [foo] } }"""))
         val expectedUserReservedFields = UserReservedFields(type = setOf("foo"))
-        val expectedHeader = SchemaDocument.Item.Header(userReservedFields = expectedUserReservedFields)
+        val expectedHeader = SchemaHeader(userReservedFields = expectedUserReservedFields)
         assertEquals(expectedHeader, header)
         assertEquals(expectedUserReservedFields, context.userReservedFields)
     }
@@ -83,7 +83,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = headerReader.readHeader(context, ION.singleValue("schema_header::{_foo:1,_bar:2}"))
 
-        val expected = SchemaDocument.Item.Header(
+        val expected = SchemaHeader(
             openContent = bagOf(
                 "_foo" to ION.newInt(1),
                 "_bar" to ION.newInt(2),
@@ -98,7 +98,7 @@ class HeaderReaderTest {
         context.userReservedFields = UserReservedFields(footer = setOf("foo", "bar"))
         val header = headerReader.readHeader(context, ION.singleValue("schema_header::{foo:1,bar:2,user_reserved_fields:{schema_header:[foo,bar]}}"))
         val expectedUserReservedFields = UserReservedFields(header = setOf("foo", "bar"))
-        val expectedHeader = SchemaDocument.Item.Header(
+        val expectedHeader = SchemaHeader(
             userReservedFields = expectedUserReservedFields,
             openContent = bagOf(
                 "foo" to ION.newInt(1),
@@ -121,7 +121,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = reader.readHeader(context, ION.singleValue("schema_header::{type:1,foo:2}"))
 
-        val expected = SchemaDocument.Item.Header(
+        val expected = SchemaHeader(
             openContent = bagOf(
                 "type" to ION.newInt(1),
                 "foo" to ION.newInt(2),
@@ -136,7 +136,7 @@ class HeaderReaderTest {
         val context = ReaderContext()
         val header = reader.readHeader(context, ION.singleValue("schema_header::{user_reserved_fields:{ type: [a, b, c] }}"))
 
-        val expected = SchemaDocument.Item.Header(
+        val expected = SchemaHeader(
             openContent = bagOf(
                 "user_reserved_fields" to ION.singleValue("{type: [a, b, c]}"),
             )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2ReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2ReaderTest.kt
@@ -8,6 +8,7 @@ import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.ValidValue
+import com.amazon.ionschema.model.mapToSet
 import com.amazon.ionschema.reader.internal.ReaderContext
 import com.amazon.ionschema.reader.internal.TypeReader
 import io.mockk.every
@@ -76,7 +77,7 @@ class AnnotationsV2ReaderTest {
             TypeArgument.InlineType(
                 TypeDefinition(
                     setOf(
-                        Constraint.Contains(setOf("a", "b", "c").map(ION::newSymbol))
+                        Constraint.Contains(setOf("a", "b", "c").mapToSet(ION::newSymbol))
                     )
                 )
             )
@@ -101,7 +102,7 @@ class AnnotationsV2ReaderTest {
                             TypeArgument.InlineType(
                                 TypeDefinition(
                                     setOf(
-                                        Constraint.ValidValues(setOf("a", "b", "c").map { ValidValue.Value(ION.newSymbol(it)) })
+                                        Constraint.ValidValues(setOf("a", "b", "c").mapToSet { ValidValue.Value(ION.newSymbol(it)) })
                                     )
                                 )
                             )
@@ -126,12 +127,12 @@ class AnnotationsV2ReaderTest {
             TypeArgument.InlineType(
                 TypeDefinition(
                     setOf(
-                        Constraint.Contains(setOf("a", "b", "c").map(ION::newSymbol)),
+                        Constraint.Contains(setOf("a", "b", "c").mapToSet(ION::newSymbol)),
                         Constraint.Element(
                             TypeArgument.InlineType(
                                 TypeDefinition(
                                     setOf(
-                                        Constraint.ValidValues(setOf("a", "b", "c").map { ValidValue.Value(ION.newSymbol(it)) })
+                                        Constraint.ValidValues(setOf("a", "b", "c").mapToSet { ValidValue.Value(ION.newSymbol(it)) })
                                     )
                                 )
                             )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ContainsReaderTest.kt
@@ -45,7 +45,7 @@ class ContainsReaderTest {
         val actual = reader.readConstraint(context, struct["contains"])
         assertEquals(
             Constraint.Contains(
-                listOf(
+                setOf(
                     ION.newSymbol("a"),
                     ION.newInt(1),
                     ION.newBool(true),

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/LogicConstraintsReaderTest.kt
@@ -67,12 +67,12 @@ class LogicConstraintsReaderTest {
         val mockType1 = mockk<TypeArgument>()
         val mockType2 = mockk<TypeArgument>()
 
-        every { typeReader.readTypeArgumentList(any(), any()) } returns listOf(mockType1, mockType2)
+        every { typeReader.readTypeArgumentList(any(), any()) } returns setOf(mockType1, mockType2)
 
         val struct = ION.singleValue("""{ any_of: [symbol, string] }""") as IonStruct
         val context = ReaderContext()
 
-        val expected = Constraint.AnyOf(listOf(mockType1, mockType2))
+        val expected = Constraint.AnyOf(setOf(mockType1, mockType2))
         val actual = reader.readConstraint(context, struct["any_of"])
         assertEquals(expected, actual)
     }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampOffsetReaderTest.kt
@@ -44,7 +44,7 @@ class TimestampOffsetReaderTest {
         val reader = TimestampOffsetReader()
         val context = ReaderContext()
         val expected = Constraint.TimestampOffset(
-            listOf(
+            setOf(
                 TimestampOffsetValue.fromMinutes(30),
                 TimestampOffsetValue.fromMinutes(90),
             )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/TimestampPrecisionReaderTest.kt
@@ -73,7 +73,7 @@ class TimestampPrecisionReaderTest {
         val expected = Constraint.TimestampPrecision(
             TimestampPrecisionRange(
                 ContinuousRange.Limit.Closed(TimestampPrecisionValue.Minute),
-                ContinuousRange.Limit.Unbounded(),
+                ContinuousRange.Limit.Unbounded,
             )
         )
         val result = reader.readConstraint(context, struct["timestamp_precision"])
@@ -87,7 +87,7 @@ class TimestampPrecisionReaderTest {
         val context = ReaderContext()
         val expected = Constraint.TimestampPrecision(
             TimestampPrecisionRange(
-                ContinuousRange.Limit.Unbounded(),
+                ContinuousRange.Limit.Unbounded,
                 ContinuousRange.Limit.Closed(TimestampPrecisionValue.Second),
             )
         )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReaderTest.kt
@@ -51,7 +51,7 @@ class ValidValuesReaderTest {
         val reader = ValidValuesReader()
         val context = ReaderContext()
         val expected = Constraint.ValidValues(
-            listOf(
+            setOf(
                 ValidValue.Value(ION.newInt(3)),
                 ValidValue.IonNumberRange(
                     NumberRange(
@@ -78,7 +78,7 @@ class ValidValuesReaderTest {
         val reader = ValidValuesReader()
         val context = ReaderContext()
         val expected = Constraint.ValidValues(
-            listOf(
+            setOf(
                 ValidValue.IonNumberRange(
                     NumberRange(
                         ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.ONE)),


### PR DESCRIPTION
**Issue #, if available:**

Fixes #264 

**Description of changes:**

By Commit:

* [Use sets instead of lists in the ISL model](https://github.com/amazon-ion/ion-schema-kotlin/commit/364933ce5147ed58061e50fa2f5dd32d51c1bc13)
  * Renames `TypeArgumentList` to `TypeArguments`
  * Adds `mapToSet()` convenience function (since the kotlin standard library `map` function maps to a list).
  * Changes logic constraints, contains, valid values, timestamp offset constraints to use a Set
  * Changes imports in schema header to be a set.
* [Makes ContinuousRange.Limit.Unbounded an object instead of a class](https://github.com/amazon-ion/ion-schema-kotlin/commit/e3203f29eaacf8bf0f6d3092fb2fb869be0d8eb7)
  * We only ever need one instance of `Unbounded`, so it makes sense for it to be an `object` instead of a `class`. 
* [Refactor SchemaDocument.Item](https://github.com/amazon-ion/ion-schema-kotlin/commit/b07860687fad338819e4ae5c1452d0821c982ec7)
  * Rename `Item` to `Content`, change to interface, and un-nest all members.
  * Get rid of `SchemaDocument.Item.Type` in favor of having `NamedTypeDefinition` implement `Content` directly.
  * `SchemaDocument.Item.Header` is now moved/renamed to `SchemaHeader`, and similarly with the footer.


**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
