### PR TITLE
Fix (#278) ClassCastException in OneOf implementation

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/LogicConstraints.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/constraint/LogicConstraints.kt
@@ -23,6 +23,7 @@ import com.amazon.ionschema.Violation
 import com.amazon.ionschema.Violations
 import com.amazon.ionschema.internal.DeferredReferenceManager
 import com.amazon.ionschema.internal.SchemaInternal
+import com.amazon.ionschema.internal.TypeInternal
 import com.amazon.ionschema.internal.TypeReference
 
 /**
@@ -108,7 +109,7 @@ internal class OneOf(ion: IonValue, schema: SchemaInternal, referenceManager: De
                 oneOfViolation.message = "value matches %s types, expected 1".format(validTypes.size)
 
                 validTypes.forEach {
-                    val typeDef = (it as ConstraintBase).ion
+                    val typeDef = (it as TypeInternal).isl
                     oneOfViolation.add(
                         Violation(
                             typeDef, "type_matched",

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OneOfTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/internal/constraint/OneOfTest.kt
@@ -1,0 +1,46 @@
+package com.amazon.ionschema.internal.constraint
+
+import com.amazon.ionschema.ION
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Test
+
+class OneOfTest {
+    val iss = IonSchemaSystemBuilder.standard().build()
+
+    @Test
+    fun issue278() {
+        // Reproduction of https://github.com/amazon-ion/ion-schema-kotlin/issues/278
+        val schemaText = """
+            ${'$'}ion_schema_2_0
+            type::{
+              name: foo,
+              one_of: [foo_a, foo_b]
+            }
+
+            type::{
+              name: foo_a,
+              type: struct,
+              fields: {
+                id: { type: string, occurs: required },
+              }
+            }
+
+            type::{
+              name: foo_b,
+              type: struct,
+              fields: {
+                digest: { type: string, occurs: required },
+              }
+            }
+        """
+
+        val schema = iss.newSchema(schemaText)
+        val type = schema.getType("foo")!!
+
+        // In issue #278, this was throwing a ClassCastException.
+        // This should return normally and indicate that the value is invalid.
+        val result = type.validate(ION.singleValue("""{ id: "abc", digest: "def" }"""))
+        assertFalse(result.isValid())
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

Fizes #278

**Description of changes:**

The violation messages for matching more than 1 variant of a `one_of` constraint was incorrectly casting to `ConstraintBase` instead of `TypeInternal`. This _might_ have been fine in the past, but especially since the cyclical imports fix, there are `Type`s that do not extend `ConstraintBase`.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
