### PR TITLE
Adds utility to get all symbol text declared in one or more schemas

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
@@ -1,0 +1,145 @@
+package com.amazon.ionschema.util
+
+import com.amazon.ion.IonContainer
+import com.amazon.ion.IonSymbol
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.AuthorityFilesystem
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import com.amazon.ionschema.Schema
+import com.amazon.ionschema.Type
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.model.ValidValue
+import com.amazon.ionschema.reader.IonSchemaReaderV2_0
+import java.io.File
+
+/**
+ * Utility functions for getting all the symbol texts that are "expected" by Ion Schema types.
+ *
+ * By "expected", we refer to field names, annotations, and symbol literals that are included in the type definition.
+ *
+ * Consider this example type:
+ * ```
+ * type::{
+ *   name: foo_type,
+ *   annotations: closed::[foo],
+ *   fields: {
+ *     a: int,
+ *     b: { valid_values: [1, true, yes] },
+ *     c: { type: symbol, codepoint_length: range::[1, 10] },
+ *     haystack: { type: list, contains: [needle] },
+ *   }
+ * }
+ * ```
+ * Getting the symbol texts for this type would return the set of `foo`, `a`, `b`, `c`, `yes`, `haystack`, and `needle`.
+ *
+ * Currently supports only Ion Schema 2.0.
+ */
+object SchemaSymbolsUtil {
+    /**
+     * Gets all symbol texts that are defined in all schemas in the given base path for an AuthorityFileSystem.
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun getSymbolsTextForPath(basePath: String, fileFilter: (File) -> Boolean = { it.path.endsWith(".isl") }): Set<String> {
+        val iss = IonSchemaSystemBuilder.standard()
+            .withAuthority(AuthorityFilesystem(basePath))
+            .allowTransitiveImports(false)
+            .build()
+
+        val baseDir = File(basePath)
+
+        return baseDir.walk()
+            .filter { it.isFile && fileFilter(it) }
+            .map { getSymbolsTextForSchema(iss.loadSchema(it.relativeTo(baseDir).path)) }
+            .flatten()
+            .toSet()
+    }
+
+    /**
+     * Gets all symbol texts for data that matches a [Type] that is declared in this [Schema].
+     * This does _not_ resolve imports.
+     */
+    @JvmStatic
+    @OptIn(ExperimentalIonSchemaModel::class)
+    fun getSymbolsTextForSchema(schema: Schema): Set<String> {
+        return IonSchemaReaderV2_0().readSchemaOrThrow(schema.isl).getAllSymbolsText()
+    }
+
+    /**
+     * Gets all symbol texts for data that matches a [TypeDefinition] in this [SchemaDocument]. Only the symbols that are
+     * locally defined will be included (i.e. imports are not resolved).
+     */
+    @OptIn(ExperimentalIonSchemaModel::class)
+    private fun SchemaDocument.getAllSymbolsText(): Set<String> {
+        return declaredTypes.values.flatMapTo(mutableSetOf()) {
+            it.typeDefinition.getAllSymbolsText()
+        }
+    }
+
+    /**
+     * Gets all symbol texts for data that matches this [TypeDefinition].
+     *
+     * Caveat—this _does_ include anything in a `not` constraint, so constructs like `{not:{valid_values:[foo]}}` may
+     * yield unexpected results.
+     *
+     * TODO: See if it's possible to track the `not`-depth to see whether the symbols in this [TypeDefinition] should be
+     * excluded or included in the final result.
+     */
+    @OptIn(ExperimentalIonSchemaModel::class)
+    private fun TypeDefinition.getAllSymbolsText(): Set<String> {
+        val symbolText = mutableSetOf<String>()
+        for (c in constraints) {
+            when (c) {
+                is Constraint.Fields -> c.fields.forEach { (fieldName, fieldType) ->
+                    symbolText.add(fieldName)
+                    symbolText.addAll(fieldType.typeArg.getAllSymbolsText())
+                }
+                is Constraint.ValidValues -> c.values.filterIsInstance<ValidValue.Value>()
+                    .forEach { symbolText.addAll(it.value.getAllSymbolTexts()) }
+                is Constraint.Contains -> c.values.forEach { symbolText.addAll(it.getAllSymbolTexts()) }
+                is Constraint.AnnotationsV1 -> symbolText.addAll(c.annotations.map { it.text })
+                is Constraint.AnnotationsV2 -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.FieldNames -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.Type -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.Not -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.Element -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.OrderedElements -> c.types.forEach { symbolText.addAll(it.typeArg.getAllSymbolsText()) }
+                is Constraint.AnyOf -> c.types.forEach { symbolText.addAll(it.getAllSymbolsText()) }
+                is Constraint.AllOf -> c.types.forEach { symbolText.addAll(it.getAllSymbolsText()) }
+                is Constraint.OneOf -> c.types.forEach { symbolText.addAll(it.getAllSymbolsText()) }
+            }
+        }
+        return symbolText
+    }
+
+    @OptIn(ExperimentalIonSchemaModel::class)
+    private fun TypeArgument.getAllSymbolsText(): Set<String> {
+        return when (this) {
+            is TypeArgument.InlineType -> typeDefinition.getAllSymbolsText()
+            else -> emptySet()
+        }
+    }
+
+    /**
+     * Gets all symbol texts from a given IonValue. This includes all annotations, field names, and symbol values.
+     */
+    private fun IonValue.getAllSymbolTexts(): Set<String> {
+        val symbolTexts = mutableSetOf<String>()
+        symbolTexts.addAll(this.typeAnnotations)
+        if (!this.isNullValue) when (this) {
+            is IonSymbol -> symbolTexts.add(this.stringValue())
+            is IonContainer -> {
+                forEach {
+                    val fName = it.fieldName
+                    if (fName != null) symbolTexts.add(fName)
+                    symbolTexts.addAll(it.getAllSymbolTexts())
+                }
+            }
+        }
+        return symbolTexts
+    }
+}

--- a/ion-schema/src/test/java/com/amazon/ionschema/util/SchemaSymbolsUtilJavaApiTest.java
+++ b/ion-schema/src/test/java/com/amazon/ionschema/util/SchemaSymbolsUtilJavaApiTest.java
@@ -1,0 +1,21 @@
+package com.amazon.ionschema.util;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+public class SchemaSymbolsUtilJavaApiTest {
+
+    @Test
+    public void testApi() {
+        // Test just to make sure that these functions are nicely usable from Java
+        Set<String> symbolTexts = SchemaSymbolsUtil.getSymbolsTextForPath(
+                "./src/main/resources/ion-schema-schemas/",
+                // This lambda could be omitted, except that the ion-schema-schemas directory contains ISL 1.0, and
+                // the SchemaSymbolsUtil doesn't support that yet.
+                f -> f.getPath().contains("isl/ion_schema_2_0")
+        );
+        Assertions.assertEquals(SchemaSymbolsUtilTest.ION_SCHEMA_2_0_SYMBOLS, symbolTexts);
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtilTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtilTest.kt
@@ -1,0 +1,147 @@
+package com.amazon.ionschema.util
+
+import com.amazon.ionschema.IonSchemaSystemBuilder
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SchemaSymbolsUtilTest {
+
+    companion object {
+        @JvmField
+        val ION_SCHEMA_2_0_SYMBOLS = setOf(
+            // Version marker
+            "\$ion_schema_2_0",
+            // Built in types
+            "any", "\$any",
+            "blob", "\$blob",
+            "bool", "\$bool",
+            "clob", "\$clob",
+            "decimal", "\$decimal",
+            "document",
+            "float", "\$float",
+            "int", "\$int",
+            "list", "\$list",
+            "lob", "\$lob",
+            "nothing",
+            "\$null",
+            "number", "\$number",
+            "sexp", "\$sexp",
+            "string", "\$string",
+            "struct", "\$struct",
+            "symbol", "\$symbol",
+            "text", "\$text",
+            "timestamp", "\$timestamp",
+            // Keywords
+            "all_of",
+            "annotations",
+            "any_of",
+            "as",
+            "byte_length",
+            "codepoint_length",
+            "container_length",
+            "contains",
+            "element",
+            "exponent",
+            "field_names",
+            "fields",
+            "id",
+            "ieee754_float",
+            "imports",
+            "name",
+            "not",
+            "occurs",
+            "one_of",
+            "ordered_elements",
+            "precision",
+            "regex",
+            "schema_footer",
+            "schema_header",
+            "timestamp_offset",
+            "timestamp_precision",
+            "type",
+            "user_reserved_fields",
+            "utf8_byte_length",
+            "valid_values",
+            // Ranges
+            "range",
+            "min",
+            "max",
+            "exclusive",
+            "optional",
+            "required",
+            // Timestamp Precisions
+            "year",
+            "month",
+            "day",
+            "minute",
+            "second",
+            "millisecond",
+            "microsecond",
+            "nanosecond",
+            // Float types
+            "binary16",
+            "binary32",
+            "binary64",
+            // Misc modifier annotations
+            "i",
+            "m",
+            "closed",
+            "distinct",
+            "required",
+            "\$null_or",
+        )
+    }
+
+    @Test
+    fun `Ion Schema 2 0 should have expected symbols`() {
+        val symbols = SchemaSymbolsUtil.getSymbolsTextForPath("./src/main/resources/ion-schema-schemas/") { it.path.contains("isl/ion_schema_2_0") }
+        // Sorted so that it's easier to see the diff when this test fails
+        assertEquals(ION_SCHEMA_2_0_SYMBOLS.sorted(), symbols.sorted())
+    }
+
+    @Test
+    fun `getSymbolsTextForSchema should get all expected symbols in a schema`() {
+        val schema = """
+            ${'$'}ion_schema_2_0
+            type::{
+              name: foo_type,
+              annotations: closed::[foo],
+              fields: {
+                a1: int,
+                a2: { valid_values: [1, true, yes] },
+                a3: { type: symbol, codepoint_length: range::[1, 10] },
+                haystack: { type: list, contains: [needle] },
+              }
+            }
+            
+            type::{
+              name: bar_type,
+              type: {
+                one_of: [
+                  { 
+                    any_of: [
+                      { valid_values: [a, b, c] },
+                      { annotations: required::[d, e, f] },
+                    ]
+                  },
+                  { 
+                    all_of: [
+                      { contains: [g, h, i] },
+                      { not: { fields: { j: nothing } } }
+                    ] 
+                  }
+                ]
+              }
+            }
+        """.trimIndent()
+        val expected = setOf(
+            "foo", "a1", "a2", "a3", "yes", "haystack", "needle",
+            "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
+        )
+        val iss = IonSchemaSystemBuilder.standard().build()
+
+        val symbols = SchemaSymbolsUtil.getSymbolsTextForSchema(iss.newSchema(schema))
+        // Sorted so that it's easier to see the diff when this test fails
+        assertEquals(expected.sorted(), symbols.sorted())
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

None.

**Description of changes:**

Adds a utility that will get all of the symbols defined for types in schemas (i.e. all of the expected/possible field names, annotations, and valid values that the types define).

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None.

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
