### PR TITLE
Add optimization to fail-fast on annotations

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/IonSchemaSystemImpl.kt
@@ -185,5 +185,9 @@ internal class IonSchemaSystemImpl(
         // for backwards compatibility with v1.1
         // Default is to keep the backward compatible behavior
         object ALLOW_TRANSITIVE_IMPORTS : Param<Boolean>(true)
+        // Introduced in v1.7.0.
+        // This is a performance improvement that skips all other constraints if the
+        // annotation doesn't match, regardless of whether the fail-fast was called.
+        object SHORT_CIRCUIT_ON_INVALID_ANNOTATIONS : Param<Boolean>(false)
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
@@ -45,12 +45,12 @@ internal class TypeImpl(
         /**
          * Order in which constraints should be evaluated. Lower is first.
          *
-         * The [validate] function in this class has
+         * The [validate] function in this class has optional short-circuit logic for the `annotations` constraint, so
+         * `annotations` gets special treatment and will be evaluated first.
          */
         private val CONSTRAINT_EVALUATION_ORDER = mapOf(
             "annotations" to -1,
             // By default, all constraints are priority 0
-            "ordered_elements" to 1,
         )
         private val CONSTRAINT_PRIORITY_COMPARATOR = Comparator<Constraint> {
             a, b ->

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeImpl.kt
@@ -21,6 +21,7 @@ import com.amazon.ion.IonValue
 import com.amazon.ion.system.IonSystemBuilder
 import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.Violations
+import com.amazon.ionschema.internal.IonSchemaSystemImpl.Param.SHORT_CIRCUIT_ON_INVALID_ANNOTATIONS
 import com.amazon.ionschema.internal.constraint.ConstraintBase
 import com.amazon.ionschema.internal.util.markReadOnly
 
@@ -40,6 +41,22 @@ internal class TypeImpl(
     private companion object {
         private val ION = IonSystemBuilder.standard().build()
         private val ANY = ION.newSymbol("any")
+
+        /**
+         * Order in which constraints should be evaluated. Lower is first.
+         *
+         * The [validate] function in this class has
+         */
+        private val CONSTRAINT_EVALUATION_ORDER = mapOf(
+            "annotations" to -1,
+            // By default, all constraints are priority 0
+            "ordered_elements" to 1,
+        )
+        private val CONSTRAINT_PRIORITY_COMPARATOR = Comparator<Constraint> {
+            a, b ->
+            CONSTRAINT_EVALUATION_ORDER.getOrDefault(a.name, 0)
+                .compareTo(CONSTRAINT_EVALUATION_ORDER.getOrDefault(b.name, 0))
+        }
     }
 
     override val isl = ionStruct.markReadOnly()
@@ -60,6 +77,8 @@ internal class TypeImpl(
                 constraints.add(TypeReference.create(ANY, schema, referenceManager)())
             }
         }
+
+        constraints.sortWith(CONSTRAINT_PRIORITY_COMPARATOR)
 
         if (schema is SchemaImpl_2_0) schema.validateFieldNamesInType(ionStruct)
     }
@@ -84,7 +103,27 @@ internal class TypeImpl(
     override fun isValidForBaseType(value: IonValue) = getBaseType().isValidForBaseType(value)
 
     override fun validate(value: IonValue, issues: Violations) {
-        constraints.forEach {
+        val constraintIterator = constraints.iterator()
+
+        // Handle short-circuit returns for `annotations`, if enabled
+        if (schema.getSchemaSystem().getParam(SHORT_CIRCUIT_ON_INVALID_ANNOTATIONS)) {
+            // To avoid adding unnecessary branches for all the constraints that are not "annotations",
+            // this short circuit logic will run until there is a constraint that is not named "annotations"
+            // and then fall back to the default logic for the remaining constraints.
+            while (constraintIterator.hasNext()) {
+                val c = constraintIterator.next()
+                if (c.name == "annotations") {
+                    val checkpoint = issues.checkpoint()
+                    c.validate(value, issues)
+                    if (!checkpoint.isValid()) return
+                } else {
+                    // No more "annotations", so handle normally and then exit the loop
+                    c.validate(value, issues)
+                    break
+                }
+            }
+        }
+        constraintIterator.forEach {
             it.validate(value, issues)
         }
     }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/FailFastOnInvalidAnnotationsTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/FailFastOnInvalidAnnotationsTest.kt
@@ -1,0 +1,88 @@
+package com.amazon.ionschema
+
+import com.amazon.ion.IonValue
+import com.amazon.ion.system.IonSystemBuilder
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+
+class FailFastOnInvalidAnnotationsTest {
+
+    companion object {
+        const val FOO_BAR_BAZ_SCHEMA_ISL_1 = """
+            type::{
+              name: symbol_or_int_list,
+              one_of:[
+                {
+                  annotations: closed::required::[symbols],
+                  element: symbol,
+                },
+                {
+                  annotations: closed::required::[ints],
+                  element: int,
+                },
+                {
+                  annotations: closed::required::[],
+                  valid_values: [null],
+                }
+              ]
+            }
+        """
+        const val FOO_BAR_BAZ_SCHEMA_ISL_2 = "\$ion_schema_2_0 \n $FOO_BAR_BAZ_SCHEMA_ISL_1"
+    }
+    val ion = IonSystemBuilder.standard().build()
+
+    val values = ion.loader.load(
+        """
+        symbols::[a, b, c, d, e]
+        ints::[1, 2, 3, 4, 5]
+        ints::[a, b, c, d, e] // invalid
+        null
+        """.trimIndent()
+    )
+
+    val failFastSystem = IonSchemaSystemBuilder.standard().failFastOnInvalidAnnotations(true).build()
+    val failSlowSystem = IonSchemaSystemBuilder.standard().failFastOnInvalidAnnotations(false).build()
+
+    @Test
+    fun testAnnotationFastFailImprovesIonSchema1() {
+        val typeName = "symbol_or_int_list"
+        benchmark("Warmup 1", failSlowSystem, FOO_BAR_BAZ_SCHEMA_ISL_1, typeName, values)
+        benchmark("Warmup 2", failFastSystem, FOO_BAR_BAZ_SCHEMA_ISL_1, typeName, values)
+        val isl1Baseline = benchmark("ISL 1.0 Baseline", failSlowSystem, FOO_BAR_BAZ_SCHEMA_ISL_1, typeName, values)
+        val isl1FastFail = benchmark("ISL 1.0 Fast Fail", failFastSystem, FOO_BAR_BAZ_SCHEMA_ISL_1, typeName, values)
+        println("Change: ${(isl1FastFail - isl1Baseline) / isl1Baseline}")
+
+        assertTrue(isl1FastFail > isl1Baseline)
+    }
+
+    @Test
+    fun testAnnotationFastFailImprovesIonSchema2() {
+        val typeName = "symbol_or_int_list"
+        benchmark("Warmup 1", failSlowSystem, FOO_BAR_BAZ_SCHEMA_ISL_2, typeName, values)
+        benchmark("Warmup 2", failFastSystem, FOO_BAR_BAZ_SCHEMA_ISL_2, typeName, values)
+        val isl2Baseline = benchmark("ISL 2.0 Baseline", failSlowSystem, FOO_BAR_BAZ_SCHEMA_ISL_2, typeName, values)
+        val isl2FastFail = benchmark("ISL 2.0 Fast Fail", failFastSystem, FOO_BAR_BAZ_SCHEMA_ISL_2, typeName, values)
+        println("Change: ${(isl2FastFail - isl2Baseline) / isl2Baseline}")
+
+        assertTrue(isl2FastFail > isl2Baseline)
+    }
+
+    private fun benchmark(name: String, iss: IonSchemaSystem, schemaString: String, typeName: String, values: List<IonValue>): Double {
+        val schema = iss.newSchema(schemaString)
+
+        val fooType = schema.getType(typeName)!!
+        val totalOps = 10000
+        val times = (1..30).map {
+            val start = System.nanoTime()
+            for (i in 1..totalOps) {
+                fooType.validate(values[i % values.size])
+            }
+            val end = System.nanoTime()
+            end - start
+        }
+        // ops/s = ops/t_avg * ns/s
+        val opsPerSecond = totalOps / times.average() * 1000000000
+        println("$name ops/s = $opsPerSecond")
+        return opsPerSecond
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/IonSchemaTestsRunner.kt
@@ -54,7 +54,9 @@ class IonSchemaTests_2_0 : TestFactory by IonSchemaTestsRunner(v2_0)
  */
 class IonSchemaTestsRunner(
     islVersion: IonSchemaVersion,
-    systemBuilder: IonSchemaSystemBuilder = IonSchemaSystemBuilder.standard().allowTransitiveImports(false),
+    systemBuilder: IonSchemaSystemBuilder = IonSchemaSystemBuilder.standard()
+        .allowTransitiveImports(false)
+        .failFastOnInvalidAnnotations(true),
     additionalFileFilter: (File) -> Boolean = { true },
     private val testNameFilter: (String) -> Boolean = { true },
 ) : TestFactory {


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Allows users to configure their schema system to fail early if a value does not match the annotations constraint for a type.
This is useful for cases where people use annotations to indicate the type of a value. For example:
```
type::{
  name: Address,
  one_of: [
    {
      annotations: required::closed::[PoBox],
      fields: {
        addressee: string,
        box_no: int,
        zip: int,
      }
    },
    {
      annotations: required::closed::[StreetAddress],
      fields: {
        addressee: string,
        street: string,
        city: string,
        state: string,
        zip: int,
      }
  ],
}
```
In this case, if a struct is annotated with `PoBox`, then there's not much point in checking it against the fields of the `StreetAddress` type. This has the benefit of reducing noise in the violations messages (why bother telling me how my `PoBox` value fails to be a `StreetAddress`—I already know it's not a `StreetAddress`), and improving performance (when calling `Type.validate()`) because it short circuits _some_ of the validation.

The exact performance improvement depends on the usage patterns, but in general, the more nesting there is inside a type/value that has an annotation, the larger the performance improvement will be.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
