### PR TITLE
Minor improvements to Ion Schema Model

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ContinuousRange.kt
@@ -92,7 +92,7 @@ data class ContinuousRange<T : Comparable<T>>(val start: Limit<T>, val end: Limi
         val lowerBrace = if (start is Limit.Closed) '[' else '('
         val lowerValue = start.value ?: "  "
         val upperValue = end.value ?: "  "
-        val upperBrace = if (end is Limit.Closed) ')' else ')'
+        val upperBrace = if (end is Limit.Closed) ']' else ')'
         return "$lowerBrace$lowerValue,$upperValue$upperBrace"
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/AnnotationsV2Reader.kt
@@ -34,15 +34,15 @@ internal class AnnotationsV2Reader(private val typeReader: TypeReader) : Constra
                 field.islRequireElementType<IonSymbol>("list of annotations")
 
                 val modifier = if (field.hasTypeAnnotation("closed") && field.hasTypeAnnotation("required")) {
-                    Constraint.AnnotationsV2.Modifier.ClosedAndRequired
+                    Constraint.AnnotationsV2.Modifier.Exact
                 } else if (field.hasTypeAnnotation("required")) {
                     Constraint.AnnotationsV2.Modifier.Required
                 } else {
                     Constraint.AnnotationsV2.Modifier.Closed
                 }
-                Constraint.AnnotationsV2.create(modifier, field.filterIsInstance<IonSymbol>().toSet())
+                Constraint.AnnotationsV2.Simplified(modifier, field.mapTo(mutableSetOf()) { (it as IonSymbol).stringValue() })
             }
-            is IonStruct, is IonSymbol -> Constraint.AnnotationsV2(typeReader.readTypeArg(context, field))
+            is IonStruct, is IonSymbol -> Constraint.AnnotationsV2.Standard(typeReader.readTypeArg(context, field))
             else -> throw InvalidSchemaException(invalidConstraint(field, "must be a type argument (symbol or struct) or a list of valid annotations"))
         }
     }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
@@ -102,7 +102,8 @@ object SchemaSymbolsUtil {
                     .forEach { symbolText.addAll(it.value.getAllSymbolTexts()) }
                 is Constraint.Contains -> c.values.forEach { symbolText.addAll(it.getAllSymbolTexts()) }
                 is Constraint.AnnotationsV1 -> symbolText.addAll(c.annotations.map { it.text })
-                is Constraint.AnnotationsV2 -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.AnnotationsV2.Standard -> symbolText.addAll(c.type.getAllSymbolsText())
+                is Constraint.AnnotationsV2.Simplified -> symbolText.addAll(c.annotations)
                 is Constraint.FieldNames -> symbolText.addAll(c.type.getAllSymbolsText())
                 is Constraint.Type -> symbolText.addAll(c.type.getAllSymbolsText())
                 is Constraint.Not -> symbolText.addAll(c.type.getAllSymbolsText())


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

* Updates the `AnnotationsV2` model to have special support for the simplified syntax, since it was discovered that there are significant performance improvements by doing so. (See #287) Also updates the schema reader and `SchemaSymbolUtil` accordingly.
* Fixes a typo in `ContinuousRange.toString()`
* Adds factory functions that will allow users to create a `Fields` constraint directly from `TypeArgument`s instead of requiring `VariableOccurringTypeArgument`s.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
