### PR TITLE
Adds skeleton for ISL Writer

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/UserReservedFields.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/UserReservedFields.kt
@@ -1,3 +1,6 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
 package com.amazon.ionschema.model
 
 /**
@@ -8,4 +11,9 @@ data class UserReservedFields(
     val type: Set<String> = emptySet(),
     val header: Set<String> = emptySet(),
     val footer: Set<String> = emptySet(),
-)
+) {
+    companion object {
+        @JvmStatic
+        val EMPTY = UserReservedFields()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/IonSchemaResult.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/IonSchemaResult.kt
@@ -14,7 +14,7 @@ sealed class IonSchemaResult<T, E : Any> {
     /**
      * Gets the [Ok] value or `null` if not [Ok].
      */
-    fun okValueOrNull(): E? = (this as? Err)?.err
+    fun okValueOrNull(): T? = (this as? Ok)?.value
 
     /**
      * Gets the [Err] value or `null` if not an [Err].

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/IonSchemaWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/IonSchemaWriter.kt
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeDefinition
+
+/**
+ * Writes Ion Schema model to an IonWriter.
+ */
+@ExperimentalIonSchemaModel
+interface IonSchemaWriter {
+    /**
+     * Writes a [SchemaDocument].
+     */
+    fun writeSchema(ionWriter: IonWriter, schemaDocument: SchemaDocument)
+
+    /**
+     * Writes an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema.
+     */
+    fun writeType(ionWriter: IonWriter, typeDefinition: TypeDefinition)
+
+    /**
+     * Writes a [NamedTypeDefinition].
+     */
+    fun writeNamedType(ionWriter: IonWriter, namedTypeDefinition: NamedTypeDefinition)
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/FooterWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/FooterWriter.kt
@@ -1,0 +1,21 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.SchemaFooter
+
+@ExperimentalIonSchemaModel
+object FooterWriter {
+    fun writeFooter(ionWriter: IonWriter, schemaFooter: SchemaFooter) {
+        ionWriter.setTypeAnnotations("schema_footer")
+        ionWriter.writeStruct {
+            for ((fieldName, fieldValue) in schemaFooter.openContent) {
+                ionWriter.setFieldName(fieldName)
+                fieldValue.writeTo(ionWriter)
+            }
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/HeaderWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/HeaderWriter.kt
@@ -1,0 +1,68 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.HeaderImport
+import com.amazon.ionschema.model.SchemaHeader
+import com.amazon.ionschema.model.UserReservedFields
+
+@ExperimentalIonSchemaModel
+object HeaderWriter {
+    fun writeHeader(ionWriter: IonWriter, schemaHeader: SchemaHeader) {
+        ionWriter.setTypeAnnotations("schema_header")
+        ionWriter.writeStruct {
+            if (schemaHeader.imports.isNotEmpty()) {
+                setFieldName("imports")
+                writeList {
+                    schemaHeader.imports.forEach { it.writeTo(ionWriter) }
+                }
+            }
+            if (schemaHeader.userReservedFields != UserReservedFields()) {
+                setFieldName("user_reserved_fields")
+                writeStruct {
+                    if (schemaHeader.userReservedFields.header.isNotEmpty()) {
+                        setFieldName("schema_header")
+                        writeList { schemaHeader.userReservedFields.header.forEach { writeSymbol(it) } }
+                    }
+                    if (schemaHeader.userReservedFields.type.isNotEmpty()) {
+                        setFieldName("type")
+                        writeList { schemaHeader.userReservedFields.type.forEach { writeSymbol(it) } }
+                    }
+                    if (schemaHeader.userReservedFields.footer.isNotEmpty()) {
+                        setFieldName("schema_footer")
+                        writeList { schemaHeader.userReservedFields.footer.forEach { writeSymbol(it) } }
+                    }
+                }
+            }
+
+            for ((fieldName, fieldValue) in schemaHeader.openContent) {
+                ionWriter.setFieldName(fieldName)
+                fieldValue.writeTo(ionWriter)
+            }
+        }
+    }
+
+    private fun HeaderImport.writeTo(ionWriter: IonWriter) {
+        ionWriter.writeStruct {
+            when (this@writeTo) {
+                is HeaderImport.Type -> {
+                    setFieldName("id")
+                    writeString(id)
+                    setFieldName("type")
+                    writeSymbol(targetType)
+                    if (asType != null) {
+                        setFieldName("as")
+                        writeSymbol(asType)
+                    }
+                }
+                is HeaderImport.Wildcard -> {
+                    setFieldName("id")
+                    writeString(id)
+                }
+            }
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/TypeWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/TypeWriter.kt
@@ -1,0 +1,38 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.TypeArgument
+import com.amazon.ionschema.model.TypeArguments
+import com.amazon.ionschema.model.VariablyOccurringTypeArgument
+
+@ExperimentalIonSchemaModel
+internal interface TypeWriter {
+
+    /**
+     * Writes a [NamedTypeDefinition] to the given [IonWriter].
+     */
+    fun writeNamedTypeDefinition(ionWriter: IonWriter, namedTypeDefinition: NamedTypeDefinition)
+
+    /**
+     * Writes a [TypeArgument] to the given [IonWriter].
+     */
+    fun writeTypeArg(ionWriter: IonWriter, typeArg: TypeArgument)
+
+    /**
+     * Writes a [VariablyOccurringTypeArgument] to the given [IonWriter].
+     */
+    fun writeVariablyOccurringTypeArg(ionWriter: IonWriter, varTypeArg: VariablyOccurringTypeArgument, elideOccursValue: DiscreteIntRange)
+
+    /**
+     * Writes a [TypeArguments] to the given [IonWriter].
+     */
+    fun writeTypeArguments(ionWriter: IonWriter, typeArgs: TypeArguments) {
+        ionWriter.writeList { typeArgs.forEach { writeTypeArg(ionWriter, it) } }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/TypeWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/TypeWriter.kt
@@ -33,6 +33,6 @@ internal interface TypeWriter {
      * Writes a [TypeArguments] to the given [IonWriter].
      */
     fun writeTypeArguments(ionWriter: IonWriter, typeArgs: TypeArguments) {
-        ionWriter.writeList { typeArgs.forEach { writeTypeArg(ionWriter, it) } }
+        ionWriter.writeToList(typeArgs) { writeTypeArg(ionWriter, it) }
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ConstraintWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ConstraintWriter.kt
@@ -6,6 +6,7 @@ package com.amazon.ionschema.writer.internal.constraints
 import com.amazon.ion.IonWriter
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import kotlin.reflect.KClass
 
 /**
  * Allows us to compose TypeWriters out of different combinations of constraint writers to enable code reuse across
@@ -14,14 +15,21 @@ import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 @ExperimentalIonSchemaModel
 internal interface ConstraintWriter {
     /**
-     * Returns true if this constraint reader can read the given constraint.
+     * Returns the constraint types that can be written by this constraint writer.
      */
-    fun canWrite(constraint: Constraint): Boolean
+    val supportedClasses: Set<KClass<out Constraint>>
 
     /**
      * Writes a [Constraint] instance to the given IonWriter.
-     * Should only be called after checking whether the constraint is supported by calling [canWrite].
      * Must throw [IllegalStateException] if called for an unsupported constraint type.
+     * Equivalent to [write], but more convenient for callers.
      */
-    fun Constraint.writeTo(ionWriter: IonWriter)
+    fun writeTo(ionWriter: IonWriter, constraint: Constraint) = ionWriter.write(constraint)
+
+    /**
+     * Writes a [Constraint] instance to the given IonWriter.
+     * Must throw [IllegalStateException] if called for an unsupported constraint type.
+     * Equivalent to [writeTo], but more convenient for implementers.
+     */
+    fun IonWriter.write(c: Constraint)
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ConstraintWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ConstraintWriter.kt
@@ -1,0 +1,27 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+
+/**
+ * Allows us to compose TypeWriters out of different combinations of constraint writers to enable code reuse across
+ * multiple Ion Schema versions.
+ */
+@ExperimentalIonSchemaModel
+internal interface ConstraintWriter {
+    /**
+     * Returns true if this constraint reader can read the given constraint.
+     */
+    fun canWrite(constraint: Constraint): Boolean
+
+    /**
+     * Writes a [Constraint] instance to the given IonWriter.
+     * Should only be called after checking whether the constraint is supported by calling [canWrite].
+     * Must throw [IllegalStateException] if called for an unsupported constraint type.
+     */
+    fun Constraint.writeTo(ionWriter: IonWriter)
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/util.kt
@@ -1,0 +1,31 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.IonType
+import com.amazon.ion.IonWriter
+
+/**
+ * Steps into a struct, writes [content] to this [IonWriter], and steps out of the struct in a `finally` block.
+ */
+internal inline fun IonWriter.writeStruct(content: IonWriter.() -> Unit) {
+    try {
+        stepIn(IonType.STRUCT)
+        content()
+    } finally {
+        stepOut()
+    }
+}
+
+/**
+ * Steps into a list, writes [content] to this [IonWriter], and steps out of the list in a `finally` block.
+ */
+internal inline fun IonWriter.writeList(content: IonWriter.() -> Unit) {
+    try {
+        stepIn(IonType.LIST)
+        content()
+    } finally {
+        stepOut()
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/util.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/util.kt
@@ -4,6 +4,7 @@
 package com.amazon.ionschema.writer.internal
 
 import com.amazon.ion.IonType
+import com.amazon.ion.IonValue
 import com.amazon.ion.IonWriter
 
 /**
@@ -13,6 +14,21 @@ internal inline fun IonWriter.writeStruct(content: IonWriter.() -> Unit) {
     try {
         stepIn(IonType.STRUCT)
         content()
+    } finally {
+        stepOut()
+    }
+}
+
+/**
+ * Steps into a struct, invokes [valueWriter] for each element of [values], and steps out of the struct in a `finally` block.
+ */
+internal inline fun <T> IonWriter.writeToStruct(values: Map<String, T>, valueWriter: IonWriter.(T) -> Unit) {
+    try {
+        stepIn(IonType.STRUCT)
+        values.forEach { (k, v) ->
+            setFieldName(k)
+            valueWriter(v)
+        }
     } finally {
         stepOut()
     }
@@ -29,3 +45,20 @@ internal inline fun IonWriter.writeList(content: IonWriter.() -> Unit) {
         stepOut()
     }
 }
+
+/**
+ * Steps into a list, invokes [valueWriter] for each element of [values], and steps out of the list in a `finally` block.
+ */
+internal inline fun <T> IonWriter.writeToList(values: Iterable<T>, valueWriter: IonWriter.(T) -> Unit) {
+    try {
+        stepIn(IonType.LIST)
+        values.forEach { valueWriter(it) }
+    } finally {
+        stepOut()
+    }
+}
+
+/**
+ * Writes an [IonValue] to an [IonWriter].
+ */
+internal fun IonWriter.writeIonValue(value: IonValue) = value.writeTo(this)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/TestUtil.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/TestUtil.kt
@@ -21,7 +21,9 @@ import com.amazon.ion.IonString
 import com.amazon.ion.IonStruct
 import com.amazon.ion.IonText
 import com.amazon.ion.IonValue
+import com.amazon.ion.IonWriter
 import com.amazon.ion.system.IonSystemBuilder
+import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 
@@ -76,3 +78,18 @@ fun Type.assertValidity(expectIsValid: Boolean, value: IonValue) {
 }
 
 internal fun IonStruct.getTextField(fieldName: String) = (get(fieldName) as IonText).stringValue()
+
+/**
+ * Asserts that the values written to an [IonWriter] match the expected Ion.
+ */
+fun assertEqualIon(expected: String, block: (IonWriter) -> Unit) = assertEqualIon(ION.loader.load(expected), block)
+
+/**
+ * Asserts that the values written to an [IonWriter] match the expected Ion.
+ */
+fun assertEqualIon(expected: IonDatagram, block: (IonWriter) -> Unit) {
+    val newDg = ION.newDatagram()
+    val ionWriter = ION.newWriter(newDg)
+    ionWriter.apply(block)
+    Assertions.assertEquals(expected, newDg)
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/FooterWriterTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/FooterWriterTest.kt
@@ -1,0 +1,34 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.assertEqualIon
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.SchemaFooter
+import com.amazon.ionschema.util.bagOf
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class FooterWriterTest {
+
+    val ION = IonSystemBuilder.standard().build()
+    private val footerWriter = FooterWriter
+
+    @Test
+    fun `writeFooter can write an empty footer`() {
+        assertEqualIon("schema_footer::{}") { w -> footerWriter.writeFooter(w, SchemaFooter()) }
+    }
+
+    @Test
+    fun `writeFooter can write a footer with open content`() {
+        val footer = SchemaFooter(
+            openContent = bagOf(
+                "foo" to ION.newInt(1),
+                "bar" to ION.newInt(2),
+            )
+        )
+        assertEqualIon("schema_footer::{foo:1,bar:2}") { w -> footerWriter.writeFooter(w, footer) }
+    }
+}

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/HeaderWriterTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/HeaderWriterTest.kt
@@ -1,0 +1,86 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal
+
+import com.amazon.ion.system.IonSystemBuilder
+import com.amazon.ionschema.assertEqualIon
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.HeaderImport
+import com.amazon.ionschema.model.SchemaHeader
+import com.amazon.ionschema.model.UserReservedFields
+import com.amazon.ionschema.util.bagOf
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class HeaderWriterTest {
+    val ION = IonSystemBuilder.standard().build()
+    private val headerWriter = HeaderWriter
+
+    @Test
+    fun `writeHeader can write an empty header`() {
+        assertEqualIon("schema_header::{}") { w -> headerWriter.writeHeader(w, SchemaHeader()) }
+    }
+
+    @Test
+    fun `writeHeader can write a header with open content`() {
+        val header = SchemaHeader(
+            openContent = bagOf(
+                "foo" to ION.newInt(1),
+                "bar" to ION.newInt(2),
+            )
+        )
+        assertEqualIon(
+            """
+            schema_header::{
+              foo:1,
+              bar:2
+            }
+        """
+        ) { w -> headerWriter.writeHeader(w, header) }
+    }
+
+    @Test
+    fun `writeHeader can write a header with imports`() {
+        val header = SchemaHeader(
+            imports = setOf(
+                HeaderImport.Wildcard("foo"),
+                HeaderImport.Type("bar", "type_a"),
+                HeaderImport.Type("baz", "type_b", asType = "type_c"),
+            ),
+        )
+        assertEqualIon(
+            """
+            schema_header::{
+              imports:[
+                {id:"foo"},
+                {id:"bar", type: type_a},
+                {id:"baz", type: type_b, as: type_c},
+              ]
+            }
+        """
+        ) { w -> headerWriter.writeHeader(w, header) }
+    }
+
+    @Test
+    fun `writeHeader can write a header with user reserved fields`() {
+        val header = SchemaHeader(
+            userReservedFields = UserReservedFields(
+                type = setOf("foo"),
+                header = setOf("bar"),
+                footer = setOf("baz"),
+            ),
+        )
+        assertEqualIon(
+            """
+            schema_header::{
+              user_reserved_fields:{
+                type: [foo],
+                schema_header: [bar],
+                schema_footer: [baz],
+              }
+            }
+        """
+        ) { w -> headerWriter.writeHeader(w, header) }
+    }
+}


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

This is the start of a writer for the Ion Schema model. It includes interfaces for a schema writer, type writer, constraint writers, and implementations of `HeaderWriter` and `FooterWriter`.

There's also a little bugfix in `IonSchemaResult`.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
