### PR TITLE
Refactors ranges and adds writers for ValidValues and TimestampPrecision

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConsistentDecimal.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConsistentDecimal.kt
@@ -26,5 +26,18 @@ class ConsistentDecimal(val bigDecimalValue: BigDecimal) : Comparable<Consistent
          */
         @JvmStatic
         fun fromIonNumber(ionNumber: IonNumber) = ConsistentDecimal(ionNumber.bigDecimalValue())
+
+        /**
+         * Translates a long value into a [ConsistentDecimal] with a scale of zero.
+         */
+        @JvmStatic
+        fun valueOf(long: Long) = ConsistentDecimal(BigDecimal.valueOf(long))
+
+        /**
+         * Translates a [Double] into a [ConsistentDecimal], using the [Double]'s canonical string representation
+         * provided by the [Double.toString] method.
+         */
+        @JvmStatic
+        fun valueOf(double: Double) = ConsistentDecimal(BigDecimal.valueOf(double))
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConsistentTimestamp.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ConsistentTimestamp.kt
@@ -27,5 +27,14 @@ class ConsistentTimestamp(val timestampValue: Timestamp) : Comparable<Consistent
          */
         @JvmStatic
         fun fromIonTimestamp(ionTimestamp: IonTimestamp) = ConsistentTimestamp(ionTimestamp.timestampValue())
+
+        /**
+         * Returns a new [ConsistentTimestamp] that represents the point in time, precision and local offset defined in
+         * Ion format by the [CharSequence].
+         *
+         * @see Timestamp.valueOf
+         */
+        @JvmStatic
+        fun valueOf(ionFormattedTimestamp: CharSequence) = ConsistentTimestamp(Timestamp.valueOf(ionFormattedTimestamp))
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Constraint.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/Constraint.kt
@@ -254,5 +254,7 @@ interface Constraint {
      *
      * @see ValidValue
      */
-    data class ValidValues(val values: Set<ValidValue>) : Constraint
+    data class ValidValues(val values: Set<ValidValue>) : Constraint {
+        constructor(vararg values: ValidValue) : this(values.toSet())
+    }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/DiscreteIntRange.kt
@@ -39,7 +39,7 @@ class DiscreteIntRange private constructor(private val delegate: ContinuousRange
      * ```
      */
     fun negate() = DiscreteIntRange(delegate.end.value?.let { it * -1 }, delegate.start.value?.let { it * -1 })
-    fun intersect(other: DiscreteIntRange): DiscreteIntRange? = delegate.intersect(other.delegate)?.let { DiscreteIntRange(it) }
+    fun intersect(other: DiscreteIntRange): DiscreteIntRange? = delegate.intersect(other.delegate)?.let { (a, b) -> DiscreteIntRange(ContinuousRange(a, b)) }
 
     operator fun contains(value: Int): Boolean = delegate.contains(value)
     override fun toString() = delegate.toString()

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TimestampPrecisionRange.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/TimestampPrecisionRange.kt
@@ -1,0 +1,16 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.model
+
+/**
+ * A [ContinuousRange] of [TimestampPrecisionValue].
+ * `TimestampPrecision` is a discrete measurement (i.e. there is no fractional number of digits of precision).
+ * However, because Ion Schema models timestamp precision as an enum, there are possible precisions that exist between
+ * the available enum values. For example, `timestamp_precision: range::[exclusive::second, exclusive::millisecond]`
+ * allows 1 or 2 digits of precision for the fractional seconds of a timestamp.
+ */
+class TimestampPrecisionRange(start: Limit<TimestampPrecisionValue>, end: Limit<TimestampPrecisionValue>) : ContinuousRange<TimestampPrecisionValue>(start, end) {
+    private constructor(value: Limit.Closed<TimestampPrecisionValue>) : this(value, value)
+    constructor(value: TimestampPrecisionValue) : this(Limit.Closed(value))
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ValidValue.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/ValidValue.kt
@@ -4,25 +4,35 @@ import com.amazon.ion.IonValue
 
 /**
  * Represents an argument to the `valid_values` constraint.
+ *
+ * Consumers of `ion-schema-kotlin` MAY NOT implement this interface.
+ *
  * @see [Constraint.ValidValues]
  */
-sealed class ValidValue {
+// TODO: Make "sealed" when updating to kotlin 1.5 or higher.
+interface ValidValue {
     /**
      * A single Ion value. May not be annotated.
      * Ignoring annotations, this value is compared using Ion equivalence with data that is being validated.
      * @see [Constraint.ValidValues]
      */
-    data class Value(val value: IonValue) : ValidValue() {
+    data class Value(val value: IonValue) : ValidValue {
         init { require(value.typeAnnotations.isEmpty()) { "valid value may not be annotated" } }
     }
 
     /**
-     * A range of numbers.
+     * A range over Ion numbers.
      */
-    data class IonNumberRange(val range: NumberRange) : ValidValue()
+    class NumberRange(start: Limit<ConsistentDecimal>, end: Limit<ConsistentDecimal>) : ValidValue, ContinuousRange<ConsistentDecimal>(start, end) {
+        private constructor(value: Limit.Closed<ConsistentDecimal>) : this(value, value)
+        constructor(value: ConsistentDecimal) : this(Limit.Closed(value))
+    }
 
     /**
      * A range of timestamp values.
      */
-    data class IonTimestampRange(val range: TimestampRange) : ValidValue()
+    class TimestampRange(start: Limit<ConsistentTimestamp>, end: Limit<ConsistentTimestamp>) : ValidValue, ContinuousRange<ConsistentTimestamp>(start, end) {
+        private constructor(value: Limit.Closed<ConsistentTimestamp>) : this(value, value)
+        constructor(value: ConsistentTimestamp) : this(Limit.Closed(value))
+    }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/model/aliases.kt
@@ -1,8 +1,6 @@
 package com.amazon.ionschema.model
 
-import com.amazon.ion.IonNumber
 import com.amazon.ion.IonValue
-import com.amazon.ion.Timestamp
 import com.amazon.ionschema.util.Bag
 
 /**
@@ -19,22 +17,3 @@ typealias OpenContentFields = Bag<Pair<String, IonValue>>
  */
 @ExperimentalIonSchemaModel
 typealias TypeArguments = Set<TypeArgument>
-
-/**
- * A [ContinuousRange] of [Timestamp], represented as a [ConsistentTimestamp].
- */
-typealias TimestampRange = ContinuousRange<ConsistentTimestamp>
-
-/**
- * A [ContinuousRange] of [IonNumber], represented as [ConsistentDecimal]
- */
-typealias NumberRange = ContinuousRange<ConsistentDecimal>
-
-/**
- * A [ContinuousRange] of [TimestampPrecisionValue].
- * `TimestampPrecision` is a discrete measurement (i.e. there is no fractional number of digits of precision).
- * However, because Ion Schema models timestamp precision as an enum, there are possible precisions that exist between
- * the available enum values. For example, `timestamp_precision: range::[exclusive::second, exclusive::millisecond]`
- * allows 1 or 2 digits of precision for the fractional seconds of a timestamp.
- */
-typealias TimestampPrecisionRange = ContinuousRange<TimestampPrecisionValue>

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReader.kt
@@ -31,8 +31,8 @@ internal class ValidValuesReader : ConstraintReader {
         val theValidValues = theList.mapToSet {
             if (it.hasTypeAnnotation("range") && it is IonList) {
                 when {
-                    it.any { x -> x is IonTimestamp } -> ValidValue.IonTimestampRange(it.toTimestampRange())
-                    it.any { x -> x is IonNumber } -> ValidValue.IonNumberRange(it.toNumberRange())
+                    it.any { x -> x is IonTimestamp } -> it.toTimestampRange()
+                    it.any { x -> x is IonNumber } -> it.toNumberRange()
                     else -> throw InvalidSchemaException("Not a valid range: $it")
                 }
             } else {

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/ranges.kt
@@ -14,23 +14,28 @@ import com.amazon.ionschema.internal.util.islRequireNoIllegalAnnotations
 import com.amazon.ionschema.model.ConsistentDecimal
 import com.amazon.ionschema.model.ConsistentTimestamp
 import com.amazon.ionschema.model.ContinuousRange
+import com.amazon.ionschema.model.ContinuousRange.Limit
 import com.amazon.ionschema.model.DiscreteIntRange
-import com.amazon.ionschema.model.NumberRange
 import com.amazon.ionschema.model.TimestampPrecisionRange
 import com.amazon.ionschema.model.TimestampPrecisionValue
-import com.amazon.ionschema.model.TimestampRange
+import com.amazon.ionschema.model.ValidValue.NumberRange
+import com.amazon.ionschema.model.ValidValue.TimestampRange
 
 /**
  * Converts an [IonValue] to a [TimestampRange].
  */
-internal fun IonValue.toTimestampRange(): TimestampRange = toContinuousRange(ConsistentTimestamp::fromIonTimestamp)
+internal fun IonValue.toTimestampRange(): TimestampRange = readRangeBoundaries(ConsistentTimestamp::fromIonTimestamp)
+    .let { (start, end) -> TimestampRange(start, end) }
 
 /**
  * Converts an [IonValue] to a [NumberRange].
  */
-internal fun IonValue.toNumberRange(): NumberRange = toContinuousRange { it: IonNumber ->
+internal fun IonValue.toNumberRange(): NumberRange = readRangeBoundaries { it: IonNumber ->
     islRequire(it.isNumericValue) { "Invalid number range; range bounds must be real numbers: $this" }
     ConsistentDecimal.fromIonNumber(it)
+}.let {
+    (start, end) ->
+    NumberRange(start, end)
 }
 
 /**
@@ -38,16 +43,21 @@ internal fun IonValue.toNumberRange(): NumberRange = toContinuousRange { it: Ion
  */
 internal fun IonValue.toTimestampPrecisionRange(): TimestampPrecisionRange {
     return when (this) {
-        is IonList -> toContinuousRange { sym: IonSymbol ->
+        is IonList -> readRangeBoundaries { sym: IonSymbol ->
             TimestampPrecisionValue.fromSymbolTextOrNull(sym.stringValue())
-                ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.valueSymbolTexts().joinToString() }, min, or max: $this")
-        }
+                ?: throw InvalidSchemaException(
+                    "Invalid timestamp precision range; range bounds must be ${
+                    TimestampPrecisionValue.valueSymbolTexts().joinToString()
+                    }, min, or max: $this"
+                )
+        }.let { (start, end) -> TimestampPrecisionRange(start, end) }
+
         is IonSymbol -> {
             islRequireIonNotNull(this) { "Timestamp precision value cannot be null; was: $this" }
             islRequireNoIllegalAnnotations(this) { "Timestamp precision value may not have annotations" }
             val precision = TimestampPrecisionValue.fromSymbolTextOrNull(stringValue())
                 ?: throw InvalidSchemaException("Invalid timestamp precision range; range bounds must be ${TimestampPrecisionValue.valueSymbolTexts().joinToString() }, min, or max: $this")
-            ContinuousRange(precision)
+            TimestampPrecisionRange(precision)
         }
         else -> throw InvalidSchemaException("Invalid range; not an ion list: $this")
     }
@@ -56,14 +66,14 @@ internal fun IonValue.toTimestampPrecisionRange(): TimestampPrecisionRange {
 /**
  * Converts an [IonValue] to a [ContinuousRange] using the given [valueFn].
  */
-private inline fun <T : Comparable<T>, reified IV : IonValue> IonValue.toContinuousRange(valueFn: (IV) -> T): ContinuousRange<T> {
+private inline fun <T : Comparable<T>, reified IV : IonValue> IonValue.readRangeBoundaries(valueFn: (IV) -> T): Pair<Limit<T>, Limit<T>> {
     return when (this) {
         is IonList -> {
             islRequire(size == 2) { "Invalid range; size of list must be 2:  $this" }
             islRequireExactAnnotations(this, "range") { "Invalid range; missing 'range' annotation:  $this" }
             val lower = readContinuousRangeBoundary(BoundaryPosition.Lower, valueFn)
             val upper = readContinuousRangeBoundary(BoundaryPosition.Upper, valueFn)
-            ContinuousRange(lower, upper)
+            return lower to upper
         }
         else -> throw InvalidSchemaException("Invalid range; not an ion list: $this")
     }
@@ -116,18 +126,18 @@ private fun IonList.readDiscreteIntRangeBoundary(bp: BoundaryPosition): Int? {
 /**
  * Reads and validates a single endpoint of a continuous value range.
  */
-private inline fun <T : Comparable<T>, reified IV : IonValue> IonList.readContinuousRangeBoundary(boundaryPosition: BoundaryPosition, valueFn: (IV) -> T): ContinuousRange.Limit<T> {
+private inline fun <T : Comparable<T>, reified IV : IonValue> IonList.readContinuousRangeBoundary(boundaryPosition: BoundaryPosition, valueFn: (IV) -> T): Limit<T> {
     val b = get(boundaryPosition.idx) ?: throw InvalidSchemaException("Invalid range; missing $boundaryPosition boundary value: $this")
     return if (b is IonSymbol && b.stringValue() == boundaryPosition.symbol) {
         islRequire(b.typeAnnotations.isEmpty()) { "Invalid range; min/max may not be annotated: $this" }
-        ContinuousRange.Limit.Unbounded
+        Limit.Unbounded
     } else {
         val value = islRequireIonTypeNotNull<IV>(b) { "Invalid range; $boundaryPosition boundary of range must be '${boundaryPosition.symbol}' or a non-null ${IV::class.simpleName}" }.let(valueFn)
         val exclusive = readBoundaryExclusivity(boundaryPosition)
         if (exclusive) {
-            ContinuousRange.Limit.Open(value)
+            Limit.Open(value)
         } else {
-            ContinuousRange.Limit.Closed(value)
+            Limit.Closed(value)
         }
     }
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/TimestampPrecisionWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/TimestampPrecisionWriter.kt
@@ -1,0 +1,20 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.writer.internal.writeTimestampPrecisionRange
+
+@ExperimentalIonSchemaModel
+internal object TimestampPrecisionWriter : ConstraintWriter {
+    override val supportedClasses = setOf(Constraint.TimestampPrecision::class)
+
+    override fun IonWriter.write(c: Constraint) {
+        check(c is Constraint.TimestampPrecision)
+        setFieldName("timestamp_precision")
+        writeTimestampPrecisionRange(c.range)
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ValidValuesWriter.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/constraints/ValidValuesWriter.kt
@@ -1,0 +1,30 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.ValidValue
+import com.amazon.ionschema.writer.internal.writeIonValue
+import com.amazon.ionschema.writer.internal.writeNumberRange
+import com.amazon.ionschema.writer.internal.writeTimestampRange
+import com.amazon.ionschema.writer.internal.writeToList
+
+@ExperimentalIonSchemaModel
+internal object ValidValuesWriter : ConstraintWriter {
+    override val supportedClasses = setOf(Constraint.ValidValues::class)
+
+    override fun IonWriter.write(c: Constraint) {
+        check(c is Constraint.ValidValues)
+        setFieldName("valid_values")
+        writeToList(c.values) {
+            when (it) {
+                is ValidValue.NumberRange -> writeNumberRange(it)
+                is ValidValue.TimestampRange -> writeTimestampRange(it)
+                is ValidValue.Value -> writeIonValue(it.value)
+            }
+        }
+    }
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/ranges.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/writer/internal/ranges.kt
@@ -4,7 +4,10 @@
 package com.amazon.ionschema.writer.internal
 
 import com.amazon.ion.IonWriter
+import com.amazon.ionschema.model.ContinuousRange
 import com.amazon.ionschema.model.DiscreteIntRange
+import com.amazon.ionschema.model.TimestampPrecisionRange
+import com.amazon.ionschema.model.ValidValue
 
 internal fun IonWriter.writeRange(range: DiscreteIntRange) {
     val (start, endInclusive) = range
@@ -17,6 +20,36 @@ internal fun IonWriter.writeRange(range: DiscreteIntRange) {
                 ?: writeSymbol("min")
             endInclusive?.let { writeInt(it.toLong()) }
                 ?: writeSymbol("max")
+        }
+    }
+}
+
+internal fun IonWriter.writeNumberRange(range: ValidValue.NumberRange) = write(range) { writeDecimal(it.bigDecimalValue) }
+internal fun IonWriter.writeTimestampRange(range: ValidValue.TimestampRange) = write(range) { writeTimestamp(it.timestampValue) }
+internal fun IonWriter.writeTimestampPrecisionRange(range: TimestampPrecisionRange) = write(range, elideSingletons = true) { writeSymbol(it.toSymbolTextOrNull()!!) }
+
+private inline fun <T : Comparable<T>> IonWriter.write(range: ContinuousRange<T>, elideSingletons: Boolean = false, writeValue: IonWriter.(T) -> Unit) {
+    if (elideSingletons && range.start is ContinuousRange.Limit.Closed && range.start == range.end) {
+        writeValue(range.start.value)
+        return
+    }
+    setTypeAnnotations("range")
+    writeList {
+        when (val start = range.start) {
+            is ContinuousRange.Limit.Unbounded -> writeSymbol("min")
+            is ContinuousRange.Limit.Closed -> writeValue(start.value)
+            is ContinuousRange.Limit.Open -> {
+                setTypeAnnotations("exclusive")
+                writeValue(start.value)
+            }
+        }
+        when (val end = range.end) {
+            is ContinuousRange.Limit.Unbounded -> writeSymbol("max")
+            is ContinuousRange.Limit.Closed -> writeValue(end.value)
+            is ContinuousRange.Limit.Open -> {
+                setTypeAnnotations("exclusive")
+                writeValue(end.value)
+            }
         }
     }
 }

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/model/ContinuousRangeTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/model/ContinuousRangeTest.kt
@@ -105,8 +105,8 @@ class ContinuousRangeTest {
         },
     ).flatten().map { (a, b, expected) ->
         "[intersect] intersection of $a and $b should be $expected" {
-            assertEquals(expected, a.intersect(b))
-            assertEquals(expected, b.intersect(a))
+            assertEquals(expected, a.intersect(b)?.let { (start, end) -> ContinuousRange(start, end) })
+            assertEquals(expected, b.intersect(a)?.let { (start, end) -> ContinuousRange(start, end) })
         }
     }
 

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReaderTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/internal/constraints/ValidValuesReaderTest.kt
@@ -8,8 +8,6 @@ import com.amazon.ionschema.model.ConsistentTimestamp
 import com.amazon.ionschema.model.Constraint
 import com.amazon.ionschema.model.ContinuousRange
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
-import com.amazon.ionschema.model.NumberRange
-import com.amazon.ionschema.model.TimestampRange
 import com.amazon.ionschema.model.ValidValue
 import com.amazon.ionschema.reader.internal.ReaderContext
 import org.junit.jupiter.api.Assertions
@@ -53,17 +51,13 @@ class ValidValuesReaderTest {
         val expected = Constraint.ValidValues(
             setOf(
                 ValidValue.Value(ION.newInt(3)),
-                ValidValue.IonNumberRange(
-                    NumberRange(
-                        ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.ONE)),
-                        ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.TEN)),
-                    )
+                ValidValue.NumberRange(
+                    ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.ONE)),
+                    ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.TEN)),
                 ),
-                ValidValue.IonTimestampRange(
-                    TimestampRange(
-                        ContinuousRange.Limit.Closed(ConsistentTimestamp(Timestamp.forDay(2022, 1, 1))),
-                        ContinuousRange.Limit.Closed(ConsistentTimestamp(Timestamp.forDay(2024, 1, 1))),
-                    )
+                ValidValue.TimestampRange(
+                    ContinuousRange.Limit.Closed(ConsistentTimestamp(Timestamp.forDay(2022, 1, 1))),
+                    ContinuousRange.Limit.Closed(ConsistentTimestamp(Timestamp.forDay(2024, 1, 1))),
                 ),
             )
         )
@@ -79,11 +73,9 @@ class ValidValuesReaderTest {
         val context = ReaderContext()
         val expected = Constraint.ValidValues(
             setOf(
-                ValidValue.IonNumberRange(
-                    NumberRange(
-                        ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.ONE)),
-                        ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.TEN)),
-                    )
+                ValidValue.NumberRange(
+                    ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.ONE)),
+                    ContinuousRange.Limit.Closed(ConsistentDecimal(BigDecimal.TEN)),
                 )
             )
         )

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/TimestampPrecisionWriterTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/TimestampPrecisionWriterTest.kt
@@ -1,0 +1,24 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ionschema.model.Constraint
+import com.amazon.ionschema.model.ContinuousRange.Limit.Closed
+import com.amazon.ionschema.model.ContinuousRange.Limit.Open
+import com.amazon.ionschema.model.ContinuousRange.Limit.Unbounded
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.TimestampPrecisionRange
+import com.amazon.ionschema.model.TimestampPrecisionValue
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class TimestampPrecisionWriterTest : ConstraintTestBase(
+    writer = TimestampPrecisionWriter,
+    expectedConstraints = setOf(Constraint.TimestampPrecision::class),
+    writeTestCases = listOf(
+        Constraint.TimestampPrecision(TimestampPrecisionRange(TimestampPrecisionValue.Second)) to "timestamp_precision: second",
+        Constraint.TimestampPrecision(TimestampPrecisionRange(Unbounded, Closed(TimestampPrecisionValue.Day))) to "timestamp_precision: range::[min, day]",
+        Constraint.TimestampPrecision(TimestampPrecisionRange(Open(TimestampPrecisionValue.Year), Closed(TimestampPrecisionValue.Day))) to "timestamp_precision: range::[exclusive::year, day]",
+        Constraint.TimestampPrecision(TimestampPrecisionRange(Closed(TimestampPrecisionValue.Day), Unbounded)) to "timestamp_precision: range::[day, max]",
+    ),
+)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/ValidValuesWriterTest.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/ValidValuesWriterTest.kt
@@ -1,0 +1,56 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ionschema.model.ConsistentDecimal
+import com.amazon.ionschema.model.ConsistentTimestamp
+import com.amazon.ionschema.model.Constraint.ValidValues
+import com.amazon.ionschema.model.ContinuousRange.Limit.Closed
+import com.amazon.ionschema.model.ContinuousRange.Limit.Open
+import com.amazon.ionschema.model.ContinuousRange.Limit.Unbounded
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.ValidValue.NumberRange
+import com.amazon.ionschema.model.ValidValue.TimestampRange
+import com.amazon.ionschema.model.ValidValue.Value
+import java.math.BigDecimal
+
+@OptIn(ExperimentalIonSchemaModel::class)
+class ValidValuesWriterTest : ConstraintTestBase(
+    writer = ValidValuesWriter,
+    expectedConstraints = setOf(ValidValues::class),
+    writeTestCases = listOf(
+        ValidValues(emptySet()) to "valid_values: []",
+        ValidValues(Value(ion("a"))) to "valid_values: [a]",
+        ValidValues(Value(ion("a")), Value(ion("b"))) to "valid_values: [a, b]",
+        // Number ranges
+        ValidValues(NumberRange(ConsistentDecimal(BigDecimal.ZERO))) to "valid_values: [range::[0., 0.]]",
+        ValidValues(NumberRange(Open(ConsistentDecimal.valueOf(1L)), Closed(ConsistentDecimal.valueOf(3L)))) to "valid_values: [range::[exclusive::1., 3.]]",
+        ValidValues(NumberRange(Closed(ConsistentDecimal.valueOf(1.0)), Unbounded)) to "valid_values: [range::[1.0, max]]",
+        ValidValues(NumberRange(Unbounded, Closed(ConsistentDecimal.valueOf(3L)))) to "valid_values: [range::[min, 3.]]",
+        // Timestamp ranges
+        ValidValues(
+            TimestampRange(
+                ConsistentTimestamp.valueOf("2023-01-01T00:00:00Z")
+            )
+        ) to "valid_values: [range::[2023-01-01T00:00:00Z, 2023-01-01T00:00:00Z]]",
+        ValidValues(
+            TimestampRange(
+                Open(ConsistentTimestamp.valueOf("2023-01-02T00:00:00Z")),
+                Closed(ConsistentTimestamp.valueOf("2023-01-04T00:00:00Z")),
+            )
+        ) to "valid_values: [range::[exclusive::2023-01-02T00:00:00Z, 2023-01-04T00:00:00Z]]",
+        ValidValues(
+            TimestampRange(
+                Closed(ConsistentTimestamp.valueOf("2023-01-05T00:00:00Z")),
+                Unbounded
+            )
+        ) to "valid_values: [range::[2023-01-05T00:00:00Z, max]]",
+        ValidValues(
+            TimestampRange(
+                Unbounded,
+                Closed(ConsistentTimestamp.valueOf("2023-01-06T00:00:00Z"))
+            )
+        ) to "valid_values: [range::[min, 2023-01-06T00:00:00Z]]",
+    )
+)

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/util.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/internal/constraints/util.kt
@@ -1,0 +1,11 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.writer.internal.constraints
+
+import com.amazon.ion.system.IonSystemBuilder
+
+private val ION = IonSystemBuilder.standard().build()
+
+/** Helper fun for creating IonValue instances */
+fun ion(text: String) = ION.singleValue(text)


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

I learned a lot about how awkward some of the APIs are while working on the `ValidValuesWriter`, so I ended up reworking some of the model to make it nicer to use.

The big changes are (1) making `ContinuousRange` an `open` class so that `TimestampRange`, etc. can be concrete classes rather than just an alias for `ContinuousRange<Timestamp>`, and (2) removing a level of wrapping in `ValidValues`. This resulted in some refactoring in the reader side.

There are also a number of smaller changes such as adding some factory methods to `ConsistentDecimal` and `ConsistentTimestamp`.

Finally, I did actually add a writer for `valid_values` and `timestamp_precision`, as well as unit testing of the same.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
