### PR TITLE
Update reader APIs

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/IonSchemaReader.kt
@@ -1,18 +1,20 @@
 package com.amazon.ionschema.reader
 
+import com.amazon.ion.IonSymbol
 import com.amazon.ion.IonValue
+import com.amazon.ionschema.IonSchemaVersion
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
-import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.SchemaDocument
-import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.reader.internal.IonSchemaReaderV2_0
 import com.amazon.ionschema.reader.internal.ReadError
+import com.amazon.ionschema.reader.internal.VersionedIonSchemaReader
 import com.amazon.ionschema.util.IonSchemaResult
 
 /**
  * Reads IonValues into the Ion Schema model.
  */
 @ExperimentalIonSchemaModel
-interface IonSchemaReader {
+object IonSchemaReader {
     /**
      * Attempts to read a [SchemaDocument]. Returns an [IonSchemaResult] containing either a [SchemaDocument] or a list
      * of [ReadError]s that were encountered.
@@ -21,44 +23,31 @@ interface IonSchemaReader {
      * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
      * errors.
      */
-    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>>
+    @JvmStatic
+    @JvmOverloads
+    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>> {
+        val maybeVersion = document
+            .firstOrNull {
+                (it is IonSymbol && !it.isNullValue && IonSchemaVersion.fromIonSymbolOrNull(it) != null) ||
+                    it.hasTypeAnnotation("schema_header") ||
+                    it.hasTypeAnnotation("schema_footer") ||
+                    it.hasTypeAnnotation("type")
+            }
+
+        val version = maybeVersion
+            ?.let { if (it is IonSymbol) IonSchemaVersion.fromIonSymbolOrNull(it) else null }
+            ?: IonSchemaVersion.v1_0
+
+        val delegate: VersionedIonSchemaReader = when (version) {
+            IonSchemaVersion.v1_0 -> TODO("IonSchemaReader does not support Ion Schema 1.0 yet.")
+            IonSchemaVersion.v2_0 -> IonSchemaReaderV2_0
+        }
+        return delegate.readSchema(document, failFast)
+    }
 
     /**
      * Reads a [SchemaDocument], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
      * if the Ion value is not a valid Ion Schema Language schema document.
      */
     fun readSchemaOrThrow(document: List<IonValue>) = readSchema(document, true).unwrap()
-
-    /**
-     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema.
-     * Returns an [IonSchemaResult] containing either a [TypeDefinition] or a list of [ReadError]s that were encountered.
-     *
-     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
-     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
-     * errors.
-     */
-    fun readType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<TypeDefinition, List<ReadError>>
-
-    /**
-     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema—
-     * throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException] if the Ion value is not a valid
-     * Ion Schema type definition.
-     */
-    fun readTypeOrThrow(ion: IonValue) = readType(ion, true).unwrap()
-
-    /**
-     * Reads a [NamedTypeDefinition]. Returns an [IonSchemaResult] containing either a [NamedTypeDefinition] or a list
-     * of [ReadError]s that were encountered.
-     *
-     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
-     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
-     * errors.
-     */
-    fun readNamedType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<NamedTypeDefinition, List<ReadError>>
-
-    /**
-     * Reads a [NamedTypeDefinition], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
-     * if the Ion value is not a valid Ion Schema named type definition.
-     */
-    fun readNamedTypeOrThrow(ion: IonValue) = readNamedType(ion, true).unwrap()
 }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/IonSchemaReaderV2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/IonSchemaReaderV2_0.kt
@@ -1,4 +1,7 @@
-package com.amazon.ionschema.reader
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.reader.internal
 
 import com.amazon.ion.IonValue
 import com.amazon.ionschema.InvalidSchemaException
@@ -9,20 +12,10 @@ import com.amazon.ionschema.model.ExperimentalIonSchemaModel
 import com.amazon.ionschema.model.NamedTypeDefinition
 import com.amazon.ionschema.model.SchemaDocument
 import com.amazon.ionschema.model.TypeDefinition
-import com.amazon.ionschema.reader.internal.FooterReader
-import com.amazon.ionschema.reader.internal.HeaderReader
-import com.amazon.ionschema.reader.internal.ReadError
-import com.amazon.ionschema.reader.internal.ReaderContext
-import com.amazon.ionschema.reader.internal.TypeReaderV2_0
-import com.amazon.ionschema.reader.internal.isFooter
-import com.amazon.ionschema.reader.internal.isHeader
-import com.amazon.ionschema.reader.internal.isTopLevelOpenContent
-import com.amazon.ionschema.reader.internal.isType
-import com.amazon.ionschema.reader.internal.readCatching
 import com.amazon.ionschema.util.IonSchemaResult
 
 @OptIn(ExperimentalIonSchemaModel::class)
-class IonSchemaReaderV2_0 : IonSchemaReader {
+internal object IonSchemaReaderV2_0 : VersionedIonSchemaReader {
     private val typeReader = TypeReaderV2_0()
     private val headerReader = HeaderReader(IonSchemaVersion.v2_0)
     private val footerReader = FooterReader { it in userReservedFields.footer || !IonSchema_2_0.RESERVED_WORDS_REGEX.matches(it) }

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/VersionedIonSchemaReader.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/reader/internal/VersionedIonSchemaReader.kt
@@ -1,0 +1,66 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package com.amazon.ionschema.reader.internal
+
+import com.amazon.ion.IonValue
+import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.model.NamedTypeDefinition
+import com.amazon.ionschema.model.SchemaDocument
+import com.amazon.ionschema.model.TypeDefinition
+import com.amazon.ionschema.util.IonSchemaResult
+
+/**
+ * Reads IonValues into the Ion Schema model.
+ */
+@ExperimentalIonSchemaModel
+interface VersionedIonSchemaReader {
+    /**
+     * Attempts to read a [SchemaDocument]. Returns an [IonSchemaResult] containing either a [SchemaDocument] or a list
+     * of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readSchema(document: Iterable<IonValue>, failFast: Boolean = false): IonSchemaResult<SchemaDocument, List<ReadError>>
+
+    /**
+     * Reads a [SchemaDocument], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
+     * if the Ion value is not a valid Ion Schema Language schema document.
+     */
+    fun readSchemaOrThrow(document: List<IonValue>) = readSchema(document, true).unwrap()
+
+    /**
+     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema.
+     * Returns an [IonSchemaResult] containing either a [TypeDefinition] or a list of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<TypeDefinition, List<ReadError>>
+
+    /**
+     * Reads an orphaned [TypeDefinition]—that is an anonymous type definition that does not belong to any schema—
+     * throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException] if the Ion value is not a valid
+     * Ion Schema type definition.
+     */
+    fun readTypeOrThrow(ion: IonValue) = readType(ion, true).unwrap()
+
+    /**
+     * Reads a [NamedTypeDefinition]. Returns an [IonSchemaResult] containing either a [NamedTypeDefinition] or a list
+     * of [ReadError]s that were encountered.
+     *
+     * If [failFast] is true, returns once a single error has been detected. Otherwise, attempts to report all errors in
+     * the given Ion. Reporting all errors is a best-effort attempt because the presence of one error can mask other
+     * errors.
+     */
+    fun readNamedType(ion: IonValue, failFast: Boolean = false): IonSchemaResult<NamedTypeDefinition, List<ReadError>>
+
+    /**
+     * Reads a [NamedTypeDefinition], throwing an [InvalidSchemaException][com.amazon.ionschema.InvalidSchemaException]
+     * if the Ion value is not a valid Ion Schema named type definition.
+     */
+    fun readNamedTypeOrThrow(ion: IonValue) = readNamedType(ion, true).unwrap()
+}

--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/util/SchemaSymbolsUtil.kt
@@ -13,7 +13,7 @@ import com.amazon.ionschema.model.SchemaDocument
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.ValidValue
-import com.amazon.ionschema.reader.IonSchemaReaderV2_0
+import com.amazon.ionschema.reader.internal.IonSchemaReaderV2_0
 import java.io.File
 
 /**
@@ -66,7 +66,7 @@ object SchemaSymbolsUtil {
     @JvmStatic
     @OptIn(ExperimentalIonSchemaModel::class)
     fun getSymbolsTextForSchema(schema: Schema): Set<String> {
-        return IonSchemaReaderV2_0().readSchemaOrThrow(schema.isl).getAllSymbolsText()
+        return IonSchemaReaderV2_0.readSchemaOrThrow(schema.isl).getAllSymbolsText()
     }
 
     /**

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/IonSchemaReaderV2_0Tests.kt
@@ -14,6 +14,7 @@ import com.amazon.ionschema.model.SchemaHeader
 import com.amazon.ionschema.model.TypeArgument
 import com.amazon.ionschema.model.TypeDefinition
 import com.amazon.ionschema.model.UserReservedFields
+import com.amazon.ionschema.reader.internal.IonSchemaReaderV2_0
 import com.amazon.ionschema.util.emptyBag
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -24,7 +25,7 @@ import kotlin.test.assertEquals
 class IonSchemaReaderV2_0Tests {
 
     val ION = IonSystemBuilder.standard().build()
-    val reader = IonSchemaReaderV2_0()
+    private val reader = IonSchemaReaderV2_0
     val typeTextWithMultipleErrors = """
             type::{
               valid_values: until_recently::["Ni!"],

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/reader/ReaderTests.kt
@@ -11,6 +11,8 @@ import com.amazon.ionschema.TestFactory
 import com.amazon.ionschema.asDocument
 import com.amazon.ionschema.getTextField
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
+import com.amazon.ionschema.reader.internal.IonSchemaReaderV2_0
+import com.amazon.ionschema.reader.internal.VersionedIonSchemaReader
 import org.junit.jupiter.api.DynamicContainer
 import org.junit.jupiter.api.DynamicNode
 import org.junit.jupiter.api.DynamicTest
@@ -44,7 +46,7 @@ class ReaderTests {
     @Nested
     inner class IonSchema_2_0 : TestFactory by ReaderTestsRunner(
         version = IonSchemaVersion.v2_0,
-        reader = IonSchemaReaderV2_0(),
+        reader = IonSchemaReaderV2_0,
         testNameFilter = { it !in ISL_2_0_EXPECTED_TO_NOT_PASS }
     )
 }
@@ -52,7 +54,7 @@ class ReaderTests {
 @ExperimentalIonSchemaModel
 class ReaderTestsRunner(
     val version: IonSchemaVersion,
-    val reader: IonSchemaReader,
+    val reader: VersionedIonSchemaReader,
     additionalFileFilter: (File) -> Boolean = { true },
     private val testNameFilter: (String) -> Boolean = { true },
 ) : TestFactory {

--- a/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/WriterTests.kt
+++ b/ion-schema/src/test/kotlin/com/amazon/ionschema/writer/WriterTests.kt
@@ -14,8 +14,8 @@ import com.amazon.ionschema.TestFactory
 import com.amazon.ionschema.asDocument
 import com.amazon.ionschema.getTextField
 import com.amazon.ionschema.model.ExperimentalIonSchemaModel
-import com.amazon.ionschema.reader.IonSchemaReader
-import com.amazon.ionschema.reader.IonSchemaReaderV2_0
+import com.amazon.ionschema.reader.internal.IonSchemaReaderV2_0
+import com.amazon.ionschema.reader.internal.VersionedIonSchemaReader
 import com.amazon.ionschema.writer.internal.IonSchemaWriterV2_0
 import com.amazon.ionschema.writer.internal.VersionedIonSchemaWriter
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -32,7 +32,7 @@ class WriterTests {
     @Nested
     inner class IonSchema_2_0 : TestFactory by WriterTestsRunner(
         version = IonSchemaVersion.v2_0,
-        reader = IonSchemaReaderV2_0(),
+        reader = IonSchemaReaderV2_0,
         writer = IonSchemaWriterV2_0,
     )
 }
@@ -40,7 +40,7 @@ class WriterTests {
 @ExperimentalIonSchemaModel
 class WriterTestsRunner(
     val version: IonSchemaVersion,
-    val reader: IonSchemaReader,
+    val reader: VersionedIonSchemaReader,
     val writer: VersionedIonSchemaWriter,
     additionalFileFilter: (File) -> Boolean = { true },
     private val testNameFilter: (String) -> Boolean = { true },


### PR DESCRIPTION
**Issue #, if available:**

None

**Description of changes:**

Updates the reader APIs so that the user doesn't have to know the schema version ahead of time. Now the specific version is an implementation detail, and the user interacts with the reader by calling `IonSchemaReader.readSchema()`.

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**

None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
