### PR TITLE
Remove extraneous clones in TypeNamed and ViolationChild

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeNamed.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/TypeNamed.kt
@@ -30,9 +30,7 @@ internal class TypeNamed(
 ) : TypeInternal by type, ConstraintBase(ion) {
 
     override fun validate(value: IonValue, issues: Violations) {
-        val struct = ion.system.newEmptyStruct()
-        struct.put("type", ion.clone())
-        val violation = Violation(struct, "type_mismatch")
+        val violation = Violation(ion, "type_mismatch")
         type.validate(value, violation)
         if (!violation.isValid()) {
             violation.message = "expected type %s".format(name)


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

I changed the implementation of `ViolationChild` so that it's not unnecessarily creating clones of `IonValue`s.
Also changed the implementation of `TypeNamed` so that it doesn't create a new struct _and_ clone the entire type definition every time it validates a value.

My informal performance testing shows a significant improvement. I created a representative schema:
```
type::{ name: A, type: int }
type::{ name: B,  type: string }
type::{ name: C, type: $any }
type::{
  name: abc,
  fields: {
    a: A,
    b: B,
    c: C,
  }
}
```
And tested it using a set of values that were all valid for the type `abc` and another set that were all invalid. These results were measured by running warmups until the time was stable, using an "[autorange](https://docs.python.org/3/library/timeit.html#timeit.Timer.autorange)" approach to determine the number of invocations in each sample, and then collecting and averaging the ops/s for 30 samples.

| Dataset | Before (ops/s) | After (ops/s) | Change |
|:-------:|---------------:|--------------:|-------:|
|  valid  |        1375113 |       2097905 |    52% |
| invalid |         865061 |       1065709 |    23% |


*Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
