### PR TITLE
Fix plusType for schema that contains only ISL 2.0 version marker

### DIFF
--- a/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
+++ b/ion-schema/src/main/kotlin/com/amazon/ionschema/internal/SchemaImpl_2_0.kt
@@ -327,14 +327,15 @@ internal class SchemaImpl_2_0 internal constructor(
 
         val newIsl = mutableListOf<IonValue>()
         var newTypeAdded = false
-        isl.forEachIndexed { idx, value ->
+        isl.forEach { value ->
             if (!newTypeAdded) {
                 if (isType(value) && (value["name"] as? IonSymbol)?.stringValue() == type.name) {
                     // new type replaces existing type of the same name
                     newIsl.add(type.isl.clone())
                     newTypeAdded = true
-                    return@forEachIndexed
-                } else if (value.hasTypeAnnotation("schema_footer") || idx == isl.lastIndex) {
+                    return@forEach
+                } else if (value.hasTypeAnnotation("schema_footer")) {
+                    // Insert the new type right before the footer
                     newIsl.add(type.isl.clone())
                     newTypeAdded = true
                 }


### PR DESCRIPTION
**Issue #, if available:**

Fixes #305 
Also related to #304 

**Description of changes:**

There was incorrect logic for handling appending a new type to a schema in `SchemaImpl_2_0.plusType()`. The `idx == isl.lastIndex` meant that the new type would be inserted _before_ the last value, no matter what it was. So, when the existing schema had only one top-level value (in this case, the `$ion_schema_2_0` version marker), the new type would be inserted before the version marker, which is illegal.

Now, the logic for adding the type in `plusType()` is as follows:
1. If we find a type with the same name, replace it with the new type
2. If we find a schema footer, insert the new type immediately before the schema footer
3. Otherwise, append to the very end of the existing schema.

(This is what it was intended to be all along.)

**Related PRs in ion-schema, ion-schema-tests, ion-schema-schemas:**
None

_By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license._
